### PR TITLE
Don’t forget self in brightness_range

### DIFF
--- a/keras_preprocessing/image.py
+++ b/keras_preprocessing/image.py
@@ -697,6 +697,9 @@ class ImageDataGenerator(object):
                  preprocessing_function=None,
                  data_format=None,
                  validation_split=0.0):
+        if brightness_range is not None and len(brightness_range) != 2:
+            raise ValueError('`brightness_range` should be tuple or list of '
+                             'two floats. Received: %s' % brightness_range)
         if data_format is None:
             data_format = backend.image_data_format()
         self.featurewise_center = featurewise_center
@@ -1054,11 +1057,7 @@ class ImageDataGenerator(object):
                                                         self.channel_shift_range)
 
         brightness = None
-        if self.brightness_range is not None:
-            if len(self.brightness_range) != 2:
-                raise ValueError(
-                    '`brightness_range should be tuple or list of two floats. '
-                    'Received: %s' % self.brightness_range)
+        if self.brightness_range:
             brightness = np.random.uniform(self.brightness_range[0],
                                            self.brightness_range[1])
 

--- a/keras_preprocessing/image.py
+++ b/keras_preprocessing/image.py
@@ -1058,7 +1058,7 @@ class ImageDataGenerator(object):
             if len(self.brightness_range) != 2:
                 raise ValueError(
                     '`brightness_range should be tuple or list of two floats. '
-                    'Received: %s' % brightness_range)
+                    'Received: %s' % self.brightness_range)
             brightness = np.random.uniform(self.brightness_range[0],
                                            self.brightness_range[1])
 


### PR DESCRIPTION
flake8 testing of https://github.com/keras-team/keras-preprocessing on Python 3.6.3

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./keras_preprocessing/image.py:1061:38: F821 undefined name 'brightness_range'
                    'Received: %s' % brightness_range)
                                     ^
./keras_preprocessing/text.py:44:29: F821 undefined name 'unicode'
        if isinstance(text, unicode):
                            ^
./keras_preprocessing/text.py:45:43: F821 undefined name 'unicode'
            translate_map = dict((ord(c), unicode(split)) for c in filters)
                                          ^
3     F821 undefined name 'brightness_range'
3
```