### PR TITLE
Change default fill_mode from nearest to constant

### DIFF
--- a/keras_preprocessing/image.py
+++ b/keras_preprocessing/image.py
@@ -43,7 +43,7 @@ if pil_image is not None:
 
 
 def random_rotation(x, rg, row_axis=1, col_axis=2, channel_axis=0,
-                    fill_mode='nearest', cval=0.):
+                    fill_mode='constant', cval=0.):
     """Performs a random rotation of a Numpy image tensor.
 
     # Arguments
@@ -68,7 +68,7 @@ def random_rotation(x, rg, row_axis=1, col_axis=2, channel_axis=0,
 
 
 def random_shift(x, wrg, hrg, row_axis=1, col_axis=2, channel_axis=0,
-                 fill_mode='nearest', cval=0.):
+                 fill_mode='constant', cval=0.):
     """Performs a random spatial shift of a Numpy image tensor.
 
     # Arguments
@@ -96,7 +96,7 @@ def random_shift(x, wrg, hrg, row_axis=1, col_axis=2, channel_axis=0,
 
 
 def random_shear(x, intensity, row_axis=1, col_axis=2, channel_axis=0,
-                 fill_mode='nearest', cval=0.):
+                 fill_mode='constant', cval=0.):
     """Performs a random spatial shear of a Numpy image tensor.
 
     # Arguments
@@ -121,7 +121,7 @@ def random_shear(x, intensity, row_axis=1, col_axis=2, channel_axis=0,
 
 
 def random_zoom(x, zoom_range, row_axis=1, col_axis=2, channel_axis=0,
-                fill_mode='nearest', cval=0.):
+                fill_mode='constant', cval=0.):
     """Performs a random spatial zoom of a Numpy image tensor.
 
     # Arguments
@@ -249,7 +249,7 @@ def transform_matrix_offset_center(matrix, x, y):
 
 def apply_affine_transform(x, theta=0, tx=0, ty=0, shear=0, zx=1, zy=1,
                            row_axis=0, col_axis=1, channel_axis=2,
-                           fill_mode='nearest', cval=0.):
+                           fill_mode='constant', cval=0.):
     """Applies an affine transformation specified by the parameters given.
 
     # Arguments
@@ -537,7 +537,7 @@ class ImageDataGenerator(object):
             If a float, `[lower, upper] = [1-zoom_range, 1+zoom_range]`.
         channel_shift_range: Float. Range for random channel shifts.
         fill_mode: One of {"constant", "nearest", "reflect" or "wrap"}.
-            Default is 'nearest'.
+            Default is 'constant'.
             Points outside the boundaries of the input are filled
             according to the given mode:
             - 'constant': kkkkkkkk|abcd|kkkkkkkk (cval=k)
@@ -689,7 +689,7 @@ class ImageDataGenerator(object):
                  shear_range=0.,
                  zoom_range=0.,
                  channel_shift_range=0.,
-                 fill_mode='nearest',
+                 fill_mode='constant',
                  cval=0.,
                  horizontal_flip=False,
                  vertical_flip=False,


### PR DESCRIPTION
The default `fill_mode='nearest'` (which was there from the very beginning) for points outside the boundaries of the input is contrary to typical value used (`'constant'`) as well as defaults in SciPy, OpenCV, and everything else I know.

Note that this is different from interpolation for for example for `load_img` (for example see https://github.com/keras-team/keras/pull/8435/)

Also see https://github.com/keras-team/keras/pull/2446

Redirected from PR https://github.com/keras-team/keras/pull/8848