### PR TITLE
Make `lower=True` in Tokenizer affect also the character level tokenization

### DIFF
--- a/keras_preprocessing/text.py
+++ b/keras_preprocessing/text.py
@@ -205,6 +205,8 @@ class Tokenizer(object):
         for text in texts:
             self.document_count += 1
             if self.char_level or isinstance(text, list):
+                if self.lower:
+                    text = text.lower()
                 seq = text
             else:
                 seq = text_to_word_sequence(text,
@@ -286,6 +288,8 @@ class Tokenizer(object):
         num_words = self.num_words
         for text in texts:
             if self.char_level or isinstance(text, list):
+                if self.lower:
+                    text = text.lower()
                 seq = text
             else:
                 seq = text_to_word_sequence(text,


### PR DESCRIPTION
Currently if one sets `lower=True` in the Tokenizer - it comes into effect only for word level tokenization (i.e., `char_level = False`).
The text remains in the original case if `char_level` is set to True.

This PR makes things consistent by converting the text to lower case also when `char_level` is set to `True`.
