### PR TITLE
Fixed oov_token with num_words and added support for reverse mapping(indices to text)

### DIFF
--- a/keras_preprocessing/text.py
+++ b/keras_preprocessing/text.py
@@ -271,9 +271,7 @@ class Tokenizer(object):
         # Returns
             A list of sequences.
         """
-        res = []
-        for vect in self.texts_to_sequences_generator(texts):
-            res.append(vect)
+        res = list(self.texts_to_sequences_generator(texts))
         return res
 
     def texts_to_sequences_generator(self, texts):
@@ -292,6 +290,7 @@ class Tokenizer(object):
             Yields individual sequences.
         """
         num_words = self.num_words
+        oov_token_index = self.word_index.get(self.oov_token)
         for text in texts:
             if self.char_level or isinstance(text, list):
                 if self.lower:
@@ -310,13 +309,11 @@ class Tokenizer(object):
                 i = self.word_index.get(w)
                 if i is not None:
                     if num_words and i >= num_words:
-                        oov_token_index = self.word_index.get(self.oov_token)
                         if oov_token_index is not None:
                             vect.append(oov_token_index)
                     else:
                         vect.append(i)
                 elif self.oov_token is not None:
-                    oov_token_index = self.word_index.get(self.oov_token)
                     vect.append(oov_token_index)
             yield vect
 
@@ -332,9 +329,7 @@ class Tokenizer(object):
         # Returns
             A list of texts (strings)
         """
-        res = []
-        for seq in self.sequences_to_texts_generator(sequences):
-            res.append(seq)
+        res = list(self.sequences_to_texts_generator(sequences))
         return res
 
     def sequences_to_texts_generator(self, sequences):
@@ -353,19 +348,18 @@ class Tokenizer(object):
             Yields individual texts.
         """
         num_words = self.num_words
+        oov_token_index = self.word_index.get(self.oov_token)
         for seq in sequences:
             vect = []
             for num in seq:
                 word = self.index_word.get(num)
                 if word is not None:
                     if num_words and num >= num_words:
-                        oov_token_index = self.word_index.get(self.oov_token)
                         if oov_token_index is not None:
                             vect.append(self.index_word[oov_token_index])
                     else:
                         vect.append(word)
                 elif self.oov_token is not None:
-                    oov_token_index = self.word_index.get(self.oov_token)
                     vect.append(self.index_word[oov_token_index])
             vect = ' '.join(vect)
             yield vect

--- a/keras_preprocessing/text.py
+++ b/keras_preprocessing/text.py
@@ -319,7 +319,7 @@ class Tokenizer(object):
                     oov_token_index = self.word_index.get(self.oov_token)
                     vect.append(oov_token_index)
             yield vect
-    
+
     def sequences_to_texts(self, sequences):
         """Transforms each sequence into a list of text.
 

--- a/keras_preprocessing/text.py
+++ b/keras_preprocessing/text.py
@@ -229,17 +229,17 @@ class Tokenizer(object):
         wcounts.sort(key=lambda x: x[1], reverse=True)
         # forcing the oov_token to index 1 if it exists
         if self.oov_token is None:
-          sorted_voc = []
+            sorted_voc = []
         else:
-          sorted_voc = [self.oov_token]            
+            sorted_voc = [self.oov_token]           
         sorted_voc.extend(wc[0] for wc in wcounts)
 
         # note that index 0 is reserved, never assigned to an existing word
         self.word_index = dict(
             list(zip(sorted_voc, list(range(1, len(sorted_voc) + 1)))))
-        
+
         self.index_word = dict((c, w) for w, c in self.word_index.items())
-        
+
         for w, c in list(self.word_docs.items()):
             self.index_docs[self.word_index[w]] = c
 
@@ -312,7 +312,7 @@ class Tokenizer(object):
                     if num_words and i >= num_words:
                         oov_token_index = self.word_index.get(self.oov_token)
                         if oov_token_index is not None:
-                          vect.append(oov_token_index)
+                            vect.append(oov_token_index)
                     else:
                         vect.append(i)
                 elif self.oov_token is not None:

--- a/keras_preprocessing/text.py
+++ b/keras_preprocessing/text.py
@@ -231,7 +231,7 @@ class Tokenizer(object):
         if self.oov_token is None:
             sorted_voc = []
         else:
-            sorted_voc = [self.oov_token]           
+            sorted_voc = [self.oov_token]
         sorted_voc.extend(wc[0] for wc in wcounts)
 
         # note that index 0 is reserved, never assigned to an existing word

--- a/keras_preprocessing/text.py
+++ b/keras_preprocessing/text.py
@@ -271,8 +271,7 @@ class Tokenizer(object):
         # Returns
             A list of sequences.
         """
-        res = list(self.texts_to_sequences_generator(texts))
-        return res
+        return list(self.texts_to_sequences_generator(texts))
 
     def texts_to_sequences_generator(self, texts):
         """Transforms each text in `texts` to a sequence of integers.
@@ -329,8 +328,7 @@ class Tokenizer(object):
         # Returns
             A list of texts (strings)
         """
-        res = list(self.sequences_to_texts_generator(sequences))
-        return res
+        return list(self.sequences_to_texts_generator(sequences))
 
     def sequences_to_texts_generator(self, sequences):
         """Transforms each sequence in `sequences` to a list of texts(strings).

--- a/keras_preprocessing/text.py
+++ b/keras_preprocessing/text.py
@@ -277,7 +277,7 @@ class Tokenizer(object):
         return res
 
     def texts_to_sequences_generator(self, texts):
-        """Transforms each text in `texts` in a sequence of integers.
+        """Transforms each text in `texts` to a sequence of integers.
 
         Each item in texts can also be a list,
         in which case we assume each item of that list to be a token.
@@ -316,8 +316,58 @@ class Tokenizer(object):
                     else:
                         vect.append(i)
                 elif self.oov_token is not None:
-                    i = self.word_index.get(self.oov_token)
-                    vect.append(i)
+                    oov_token_index = self.word_index.get(self.oov_token)
+                    vect.append(oov_token_index)
+            yield vect
+    
+    def sequences_to_texts(self, sequences):
+        """Transforms each sequence into a list of text.
+
+        Only top "num_words" most frequent words will be taken into account.
+        Only words known by the tokenizer will be taken into account.
+
+        # Arguments
+            texts: A list of sequences (list of integers).
+
+        # Returns
+            A list of texts (strings)
+        """
+        res = []
+        for seq in self.sequences_to_texts_generator(sequences):
+            res.append(seq)
+        return res
+
+    def sequences_to_texts_generator(self, sequences):
+        """Transforms each sequence in `sequences` to a list of texts(strings).
+
+        Each sequence has to a list of integers.
+        In other words, sequences should be a list of sequences
+
+        Only top "num_words" most frequent words will be taken into account.
+        Only words known by the tokenizer will be taken into account.
+
+        # Arguments
+            texts: A list of sequences.
+
+        # Yields
+            Yields individual texts.
+        """
+        num_words = self.num_words
+        for seq in sequences:
+            vect = []
+            for num in seq:
+                word = self.index_word.get(num)
+                if word is not None:
+                    if num_words and num >= num_words:
+                        oov_token_index = self.word_index.get(self.oov_token)
+                        if oov_token_index is not None:
+                            vect.append(self.index_word[oov_token_index])
+                    else:
+                        vect.append(word)
+                elif self.oov_token is not None:
+                    oov_token_index = self.word_index.get(self.oov_token)
+                    vect.append(self.index_word[oov_token_index])
+            vect = ' '.join(vect)
             yield vect
 
     def texts_to_matrix(self, texts, mode='binary'):

--- a/tests/text_test.py
+++ b/tests/text_test.py
@@ -127,7 +127,7 @@ def test_tokenizer_oov_flag():
     assert len(x_test_seq[0]) == 6  # OOVs marked in place
 
 
-def test_tokenizer_oov_flag_and_num_words(self):
+def test_tokenizer_oov_flag_and_num_words():
     x_train = ['This text has only known words this text']
     x_test = ['This text has some unknown words']
 

--- a/tests/text_test.py
+++ b/tests/text_test.py
@@ -126,7 +126,7 @@ def test_tokenizer_oov_flag():
     x_test_seq = tokenizer.texts_to_sequences(x_test)
     assert len(x_test_seq[0]) == 6  # OOVs marked in place
 
-    
+
 def test_tokenizer_oov_flag_and_num_words(self):
     x_train = ['This text has only known words this text']
     x_test = ['This text has some unknown words']
@@ -138,7 +138,7 @@ def test_tokenizer_oov_flag_and_num_words(self):
     trans_text = ' '.join(tokenizer.index_word[t] for t in x_test_seq[0])
     self.assertEqual(len(x_test_seq[0]), 6)
     self.assertEqual(trans_text, 'this <unk> <unk> <unk> <unk> <unk>')
-    
+
 
 def test_tokenizer_lower_flag():
     """Tests for `lower` flag in text.Tokenizer

--- a/tests/text_test.py
+++ b/tests/text_test.py
@@ -214,8 +214,8 @@ def test_sequences_to_texts():
     tokenized_text = tokenizer.texts_to_sequences(texts)
     trans_text = tokenizer.sequences_to_texts(tokenized_text)
     print (trans_text)
-    assert trans_text == ['the cat sat on the mat', 
-                          'the dog sat on the log', 
+    assert trans_text == ['the cat sat on the mat',
+                          'the dog sat on the log',
                           'dogs <unk> <unk> <unk> <unk>']
 
 

--- a/tests/text_test.py
+++ b/tests/text_test.py
@@ -140,6 +140,85 @@ def test_tokenizer_oov_flag_and_num_words():
     assert trans_text == 'this <unk> <unk> <unk> <unk> <unk>'
 
 
+def test_tokenizer_oov_flag_and_num_words():
+    x_train = ['This text has only known words this text']
+    x_test = ['This text has some unknown words']
+
+    tokenizer = keras.preprocessing.text.Tokenizer(num_words=3,
+                                                   oov_token='<unk>')
+    tokenizer.fit_on_texts(x_train)
+    x_test_seq = tokenizer.texts_to_sequences(x_test)
+    trans_text = ' '.join(tokenizer.index_word[t] for t in x_test_seq[0])
+    assert len(x_test_seq[0]) == 6
+    assert trans_text == 'this <unk> <unk> <unk> <unk> <unk>'
+
+
+def test_sequences_to_texts_with_num_words_and_oov_token():
+    x_train = ['This text has only known words this text']
+    x_test = ['This text has some unknown words']
+
+    tokenizer = keras.preprocessing.text.Tokenizer(num_words=3,
+                                                   oov_token='<unk>')
+
+    tokenizer.fit_on_texts(x_train)
+    x_test_seq = tokenizer.texts_to_sequences(x_test)
+    trans_text = tokenizer.sequences_to_texts(x_test_seq)
+    assert trans_text == ['this <unk> <unk> <unk> <unk> <unk>']
+
+
+def test_sequences_to_texts_no_num_words():
+    x_train = ['This text has only known words this text']
+    x_test = ['This text has some unknown words']
+
+    tokenizer = keras.preprocessing.text.Tokenizer(oov_token='<unk>')
+
+    tokenizer.fit_on_texts(x_train)
+    x_test_seq = tokenizer.texts_to_sequences(x_test)
+    trans_text = tokenizer.sequences_to_texts(x_test_seq)
+    assert trans_text == ['this text has <unk> <unk> words']
+
+
+def test_sequences_to_texts_no_oov_token():
+    x_train = ['This text has only known words this text']
+    x_test = ['This text has some unknown words']
+
+    tokenizer = keras.preprocessing.text.Tokenizer(num_words=3)
+
+    tokenizer.fit_on_texts(x_train)
+    x_test_seq = tokenizer.texts_to_sequences(x_test)
+    trans_text = tokenizer.sequences_to_texts(x_test_seq)
+    assert trans_text == ['this text']
+
+
+def test_sequences_to_texts_no_num_words_no_oov_token():
+    x_train = ['This text has only known words this text']
+    x_test = ['This text has some unknown words']
+
+    tokenizer = keras.preprocessing.text.Tokenizer()
+
+    tokenizer.fit_on_texts(x_train)
+    x_test_seq = tokenizer.texts_to_sequences(x_test)
+    trans_text = tokenizer.sequences_to_texts(x_test_seq)
+    assert trans_text == ['this text has words']
+
+
+def test_sequences_to_texts():
+    texts = [
+        'The cat sat on the mat.',
+        'The dog sat on the log.',
+        'Dogs and cats living together.'
+    ]
+    tokenizer = keras.preprocessing.text.Tokenizer(num_words=10,
+                                                   oov_token='<unk>')
+    tokenizer.fit_on_texts(texts)
+    tokenized_text = tokenizer.texts_to_sequences(texts)
+    trans_text = tokenizer.sequences_to_texts(tokenized_text)
+    print (trans_text)
+    assert trans_text == ['the cat sat on the mat', 
+                          'the dog sat on the log', 
+                          'dogs <unk> <unk> <unk> <unk>'])
+
+
 def test_tokenizer_lower_flag():
     """Tests for `lower` flag in text.Tokenizer
     """

--- a/tests/text_test.py
+++ b/tests/text_test.py
@@ -136,8 +136,8 @@ def test_tokenizer_oov_flag_and_num_words():
     tokenizer.fit_on_texts(x_train)
     x_test_seq = tokenizer.texts_to_sequences(x_test)
     trans_text = ' '.join(tokenizer.index_word[t] for t in x_test_seq[0])
-    self.assertEqual(len(x_test_seq[0]), 6)
-    self.assertEqual(trans_text, 'this <unk> <unk> <unk> <unk> <unk>')
+    assert len(x_test_seq[0]) == 6
+    assert trans_text == 'this <unk> <unk> <unk> <unk> <unk>'
 
 
 def test_tokenizer_lower_flag():

--- a/tests/text_test.py
+++ b/tests/text_test.py
@@ -126,6 +126,7 @@ def test_tokenizer_oov_flag():
     x_test_seq = tokenizer.texts_to_sequences(x_test)
     assert len(x_test_seq[0]) == 6  # OOVs marked in place
 
+    
 def test_tokenizer_oov_flag_and_num_words(self):
     x_train = ['This text has only known words this text']
     x_test = ['This text has some unknown words']
@@ -138,6 +139,7 @@ def test_tokenizer_oov_flag_and_num_words(self):
     self.assertEqual(len(x_test_seq[0]), 6)
     self.assertEqual(trans_text, 'this <unk> <unk> <unk> <unk> <unk>')
     
+
 def test_tokenizer_lower_flag():
     """Tests for `lower` flag in text.Tokenizer
     """

--- a/tests/text_test.py
+++ b/tests/text_test.py
@@ -126,7 +126,18 @@ def test_tokenizer_oov_flag():
     x_test_seq = tokenizer.texts_to_sequences(x_test)
     assert len(x_test_seq[0]) == 6  # OOVs marked in place
 
+def test_tokenizer_oov_flag_and_num_words(self):
+    x_train = ['This text has only known words this text']
+    x_test = ['This text has some unknown words']
 
+    tokenizer = keras.preprocessing.text.Tokenizer(num_words=3,
+                                                   oov_token='<unk>')
+    tokenizer.fit_on_texts(x_train)
+    x_test_seq = tokenizer.texts_to_sequences(x_test)
+    trans_text = ' '.join(tokenizer.index_word[t] for t in x_test_seq[0])
+    self.assertEqual(len(x_test_seq[0]), 6)
+    self.assertEqual(trans_text, 'this <unk> <unk> <unk> <unk> <unk>')
+    
 def test_tokenizer_lower_flag():
     """Tests for `lower` flag in text.Tokenizer
     """

--- a/tests/text_test.py
+++ b/tests/text_test.py
@@ -216,7 +216,7 @@ def test_sequences_to_texts():
     print (trans_text)
     assert trans_text == ['the cat sat on the mat', 
                           'the dog sat on the log', 
-                          'dogs <unk> <unk> <unk> <unk>'])
+                          'dogs <unk> <unk> <unk> <unk>']
 
 
 def test_tokenizer_lower_flag():


### PR DESCRIPTION
Fixed the oov_token to take the index as 1 by default. This includes the oov_token everytime when num_words is specified in the argument. Also written tests for this problem. 
Before, even when num_words and oov_token was specified, the sequences returned did not contain the oov_token. This fixes that.

Also added support for reverse mapping. In other words, if we do tokenizer.sequenes_to_texts(sequences), we get a list of strings. It converts indices to strings using a index_word mapping.

For sequences to texts conversion, I am replacing the words not in the vocabulary(includes 0 which might be used for padding) by the oov_token (if specified). Is that decision fine? WDYT? @fchollet 