### PR TITLE
Fix doc

### DIFF
--- a/keras_preprocessing/image.py
+++ b/keras_preprocessing/image.py
@@ -552,7 +552,7 @@ class ImageDataGenerator(object):
         rescale: rescaling factor. Defaults to None.
             If None or 0, no rescaling is applied,
             otherwise we multiply the data by the value provided
-            (before applying any other transformation).
+            (after applying all other transformations).
         preprocessing_function: function that will be implied on each input.
             The function will run after the image is resized and augmented.
             The function should take one argument:


### PR DESCRIPTION
Current implementation does rescale, which is done by calling `standardize`, after all other transformations. Fixed doc accordingly. 
 
https://github.com/keras-team/keras-preprocessing/blob/ea4b8e16d48e2522e6b497d7df9c04aedc63fc7b/keras_preprocessing/image.py#L1429-L1431

https://github.com/keras-team/keras-preprocessing/blob/ea4b8e16d48e2522e6b497d7df9c04aedc63fc7b/keras_preprocessing/image.py#L1737-L1738