### PR TITLE
Adapting image.py to 16 bits gray

### DIFF
--- a/keras_preprocessing/image.py
+++ b/keras_preprocessing/image.py
@@ -472,7 +472,7 @@ def load_img(path, grayscale=False, target_size=None,
                           'The use of `array_to_img` requires PIL.')
     img = pil_image.open(path)
     if grayscale:
-        if img.mode != 'L':
+        if img.mode not in ('L', 'I;16'):
             img = img.convert('L')
     else:
         if img.mode != 'RGB':


### PR DESCRIPTION
Avoid needless downsampling of 16 bits gray image to 8 bits, and current clipping from Pillow is wrong, see :
https://github.com/python-pillow/Pillow/issues/3011