### PR TITLE
Custom split

### DIFF
--- a/keras_preprocessing/text.py
+++ b/keras_preprocessing/text.py
@@ -35,8 +35,7 @@ def text_to_word_sequence(text,
             includes basic punctuation, tabs, and newlines.
         lower: boolean. Whether to convert the input to lowercase.
         split: str or func. Either a seperator for python split() or a custom split function
-            The custom split function should accept a string and return an iterable
-
+            that accepts a string and returns an iterable over tokens
     # Returns
         A list of words (or tokens).
     """
@@ -156,7 +155,7 @@ class Tokenizer(object):
             tabs and line breaks, minus the `'` character.
         lower: boolean. Whether to convert the texts to lowercase.
         split: str or func. Either a seperator for python split() or a custom split function
-            The custom split function should accept a string and return an iterable
+            that accepts a string and returns an iterable over tokens
         char_level: if True, every character will be treated as a token.
         oov_token: if given, it will be added to word_index and used to
             replace out-of-vocabulary words during text_to_sequence calls

--- a/keras_preprocessing/text.py
+++ b/keras_preprocessing/text.py
@@ -155,7 +155,8 @@ class Tokenizer(object):
             filtered from the texts. The default is all punctuation, plus
             tabs and line breaks, minus the `'` character.
         lower: boolean. Whether to convert the texts to lowercase.
-        split: str. Separator for word splitting.
+        split: str or func. Either a seperator for python split() or a custom split function
+            The custom split function should accept a string and return an iterable
         char_level: if True, every character will be treated as a token.
         oov_token: if given, it will be added to word_index and used to
             replace out-of-vocabulary words during text_to_sequence calls

--- a/keras_preprocessing/text.py
+++ b/keras_preprocessing/text.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import inspect
 import string
 import sys
 import warnings
@@ -33,7 +34,8 @@ def text_to_word_sequence(text,
             punctuation. Default: `!"#$%&()*+,-./:;<=>?@[\\]^_`{|}~\t\n`,
             includes basic punctuation, tabs, and newlines.
         lower: boolean. Whether to convert the input to lowercase.
-        split: str. Separator for word splitting.
+        split: str or func. Either a seperator for python split() or a custom split function
+            The custom split function should accept a string and return an iterable
 
     # Returns
         A list of words (or tokens).
@@ -56,7 +58,10 @@ def text_to_word_sequence(text,
         translate_map = maketrans(translate_dict)
         text = text.translate(translate_map)
 
-    seq = text.split(split)
+    if inspect.isfunction(split):
+        seq = split(text)
+    else:
+        seq = text.split(split)
     return [i for i in seq if i]
 
 


### PR DESCRIPTION
### Summary
This modification allows user an option to pass a custom split function to the `texts_to_word_sequence` function. This allows the user to easily implement custom tokenizers like Treebank tokenizers.

### Related Issues
The modification is backward compatible. The `split` argument retains current behavior as long as the argument passed is a string
### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [x] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [x] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
