### PR TITLE
interpolation `order` for ImageDataGenerator

### DIFF
--- a/keras_preprocessing/image.py
+++ b/keras_preprocessing/image.py
@@ -51,7 +51,7 @@ if pil_image is not None:
 
 
 def random_rotation(x, rg, row_axis=1, col_axis=2, channel_axis=0,
-                    fill_mode='nearest', cval=0.):
+                    fill_mode='nearest', cval=0., interpolation_order=3):
     """Performs a random rotation of a Numpy image tensor.
 
     # Arguments
@@ -65,18 +65,20 @@ def random_rotation(x, rg, row_axis=1, col_axis=2, channel_axis=0,
             (one of `{'constant', 'nearest', 'reflect', 'wrap'}`).
         cval: Value used for points outside the boundaries
             of the input if `mode='constant'`.
-
+        interpolation_order int: order of spline interpolation.
+            see `ndimage.interpolation.affine_transform`
     # Returns
         Rotated Numpy image tensor.
     """
     theta = np.random.uniform(-rg, rg)
     x = apply_affine_transform(x, theta=theta, channel_axis=channel_axis,
-                               fill_mode=fill_mode, cval=cval)
+                               fill_mode=fill_mode, cval=cval,
+                               order=interpolation_order)
     return x
 
 
 def random_shift(x, wrg, hrg, row_axis=1, col_axis=2, channel_axis=0,
-                 fill_mode='nearest', cval=0.):
+                 fill_mode='nearest', cval=0., interpolation_order=3):
     """Performs a random spatial shift of a Numpy image tensor.
 
     # Arguments
@@ -91,7 +93,8 @@ def random_shift(x, wrg, hrg, row_axis=1, col_axis=2, channel_axis=0,
             (one of `{'constant', 'nearest', 'reflect', 'wrap'}`).
         cval: Value used for points outside the boundaries
             of the input if `mode='constant'`.
-
+        interpolation_order int: order of spline interpolation.
+            see `ndimage.interpolation.affine_transform`
     # Returns
         Shifted Numpy image tensor.
     """
@@ -99,12 +102,13 @@ def random_shift(x, wrg, hrg, row_axis=1, col_axis=2, channel_axis=0,
     tx = np.random.uniform(-hrg, hrg) * h
     ty = np.random.uniform(-wrg, wrg) * w
     x = apply_affine_transform(x, tx=tx, ty=ty, channel_axis=channel_axis,
-                               fill_mode=fill_mode, cval=cval)
+                               fill_mode=fill_mode, cval=cval,
+                               order=interpolation_order)
     return x
 
 
 def random_shear(x, intensity, row_axis=1, col_axis=2, channel_axis=0,
-                 fill_mode='nearest', cval=0.):
+                 fill_mode='nearest', cval=0., interpolation_order=3):
     """Performs a random spatial shear of a Numpy image tensor.
 
     # Arguments
@@ -118,18 +122,20 @@ def random_shear(x, intensity, row_axis=1, col_axis=2, channel_axis=0,
             (one of `{'constant', 'nearest', 'reflect', 'wrap'}`).
         cval: Value used for points outside the boundaries
             of the input if `mode='constant'`.
-
+        interpolation_order int: order of spline interpolation.
+            see `ndimage.interpolation.affine_transform`
     # Returns
         Sheared Numpy image tensor.
     """
     shear = np.random.uniform(-intensity, intensity)
     x = apply_affine_transform(x, shear=shear, channel_axis=channel_axis,
-                               fill_mode=fill_mode, cval=cval)
+                               fill_mode=fill_mode, cval=cval,
+                               order=interpolation_order)
     return x
 
 
 def random_zoom(x, zoom_range, row_axis=1, col_axis=2, channel_axis=0,
-                fill_mode='nearest', cval=0.):
+                fill_mode='nearest', cval=0., interpolation_order=3):
     """Performs a random spatial zoom of a Numpy image tensor.
 
     # Arguments
@@ -143,6 +149,8 @@ def random_zoom(x, zoom_range, row_axis=1, col_axis=2, channel_axis=0,
             (one of `{'constant', 'nearest', 'reflect', 'wrap'}`).
         cval: Value used for points outside the boundaries
             of the input if `mode='constant'`.
+        interpolation_order int: order of spline interpolation.
+            see `ndimage.interpolation.affine_transform`
 
     # Returns
         Zoomed Numpy image tensor.
@@ -159,7 +167,8 @@ def random_zoom(x, zoom_range, row_axis=1, col_axis=2, channel_axis=0,
     else:
         zx, zy = np.random.uniform(zoom_range[0], zoom_range[1], 2)
     x = apply_affine_transform(x, zx=zx, zy=zy, channel_axis=channel_axis,
-                               fill_mode=fill_mode, cval=cval)
+                               fill_mode=fill_mode, cval=cval,
+                               order=interpolation_order)
     return x
 
 
@@ -260,7 +269,7 @@ def transform_matrix_offset_center(matrix, x, y):
 
 def apply_affine_transform(x, theta=0, tx=0, ty=0, shear=0, zx=1, zy=1,
                            row_axis=0, col_axis=1, channel_axis=2,
-                           fill_mode='nearest', cval=0.):
+                           fill_mode='nearest', cval=0., order=1):
     """Applies an affine transformation specified by the parameters given.
 
     # Arguments
@@ -279,6 +288,7 @@ def apply_affine_transform(x, theta=0, tx=0, ty=0, shear=0, zx=1, zy=1,
             (one of `{'constant', 'nearest', 'reflect', 'wrap'}`).
         cval: Value used for points outside the boundaries
             of the input if `mode='constant'`.
+        order int: order of interpolation
 
     # Returns
         The transformed version of the input.
@@ -334,7 +344,7 @@ def apply_affine_transform(x, theta=0, tx=0, ty=0, shear=0, zx=1, zy=1,
             x_channel,
             final_affine_matrix,
             final_offset,
-            order=1,
+            order=order,
             mode=fill_mode,
             cval=cval) for x_channel in x]
         x = np.stack(channel_images, axis=0)
@@ -775,7 +785,9 @@ class ImageDataGenerator(object):
                  preprocessing_function=None,
                  data_format='channels_last',
                  validation_split=0.0,
+                 interpolation_order=1,
                  dtype='float32'):
+
         self.featurewise_center = featurewise_center
         self.samplewise_center = samplewise_center
         self.featurewise_std_normalization = featurewise_std_normalization
@@ -795,6 +807,7 @@ class ImageDataGenerator(object):
         self.rescale = rescale
         self.preprocessing_function = preprocessing_function
         self.dtype = dtype
+        self.interpolation_order= interpolation_order
 
         if data_format not in {'channels_last', 'channels_first'}:
             raise ValueError(
@@ -1287,7 +1300,8 @@ class ImageDataGenerator(object):
                                    col_axis=img_col_axis,
                                    channel_axis=img_channel_axis,
                                    fill_mode=self.fill_mode,
-                                   cval=self.cval)
+                                   cval=self.cval,
+                                   order=self.interpolation_order)
 
         if transform_parameters.get('channel_shift_intensity') is not None:
             x = apply_channel_shift(x,

--- a/keras_preprocessing/image.py
+++ b/keras_preprocessing/image.py
@@ -51,7 +51,7 @@ if pil_image is not None:
 
 
 def random_rotation(x, rg, row_axis=1, col_axis=2, channel_axis=0,
-                    fill_mode='nearest', cval=0., interpolation_order=3):
+                    fill_mode='nearest', cval=0., interpolation_order=1):
     """Performs a random rotation of a Numpy image tensor.
 
     # Arguments
@@ -78,7 +78,7 @@ def random_rotation(x, rg, row_axis=1, col_axis=2, channel_axis=0,
 
 
 def random_shift(x, wrg, hrg, row_axis=1, col_axis=2, channel_axis=0,
-                 fill_mode='nearest', cval=0., interpolation_order=3):
+                 fill_mode='nearest', cval=0., interpolation_order=1):
     """Performs a random spatial shift of a Numpy image tensor.
 
     # Arguments
@@ -108,7 +108,7 @@ def random_shift(x, wrg, hrg, row_axis=1, col_axis=2, channel_axis=0,
 
 
 def random_shear(x, intensity, row_axis=1, col_axis=2, channel_axis=0,
-                 fill_mode='nearest', cval=0., interpolation_order=3):
+                 fill_mode='nearest', cval=0., interpolation_order=1):
     """Performs a random spatial shear of a Numpy image tensor.
 
     # Arguments
@@ -135,7 +135,7 @@ def random_shear(x, intensity, row_axis=1, col_axis=2, channel_axis=0,
 
 
 def random_zoom(x, zoom_range, row_axis=1, col_axis=2, channel_axis=0,
-                fill_mode='nearest', cval=0., interpolation_order=3):
+                fill_mode='nearest', cval=0., interpolation_order=1):
     """Performs a random spatial zoom of a Numpy image tensor.
 
     # Arguments
@@ -807,7 +807,7 @@ class ImageDataGenerator(object):
         self.rescale = rescale
         self.preprocessing_function = preprocessing_function
         self.dtype = dtype
-        self.interpolation_order= interpolation_order
+        self.interpolation_order = interpolation_order
 
         if data_format not in {'channels_last', 'channels_first'}:
             raise ValueError(

--- a/tests/image_test.py
+++ b/tests/image_test.py
@@ -69,7 +69,8 @@ class TestImage(object):
                 fill_mode='nearest',
                 cval=0.5,
                 horizontal_flip=True,
-                vertical_flip=True)
+                vertical_flip=True,
+                interpolation_order=1)
             generator.fit(images, augment=True)
 
             for x, y in generator.flow(images, np.arange(images.shape[0]),
@@ -192,6 +193,19 @@ class TestImage(object):
             seq.on_epoch_end()
             x2, y2 = seq[0]
             assert list(y) != list(y2)
+
+        # test order_interpolation
+        labels = np.array([[2, 2, 0, 2, 2],
+                           [1, 3, 2, 3, 1],
+                           [2, 1, 0, 1, 2],
+                           [3, 1, 0, 2, 0],
+                           [3, 1, 3, 2, 1]])
+
+        label_generator = image.ImageDataGenerator(rotation_range=90.,
+                                                   interpolation_order=0)
+        labels_gen = label_generator.flow(x=labels[np.newaxis, ..., np.newaxis],
+                                          seed=123)
+        assert (np.unique(labels) == np.unique(next(labels_gen))).all()
 
     def test_image_data_generator_with_validation_split(self):
         for test_images in self.all_test_images:


### PR DESCRIPTION
### Summary
ImageDataGenerator can take a keyword argument `interpolation_order` that trickles down to `scipy.ndimage.interpolation.affine_transform` that resides in `apply_affine_transform`. At the moment the order of the spline interpolation is hard coded and set to 1 [line 323](https://github.com/keras-team/keras-preprocessing/blob/master/keras_preprocessing/image.py) This causes images of class labels to transform incorrectly. The suggested fix allows to use neaset neighbours interpolation and preserve the pixel value as integers (otherwise it turns to rational numbers that have no meaning as class labels).

for example:

```python
[[2 2 0 2 2]
 [1 3 2 3 1]
 [2 1 0 1 2]
 [3 1 0 2 0]
 [3 1 3 2 1]]
```
is transformed to 
```python
[[2.289865   1.7110896  1.8507836  2.172145   0.15832195]
 [3.         2.2037435  1.0774351  1.4194988  2.3764393 ]
 [3.         1.4194988  0.39426237 0.49894607 1.7452569 ]
 [1.8929222  1.7380519  1.7849773  2.         1.2062019 ]
 [1.2646285  2.8956027  2.2367117  1.3144331  0.23671168]]
```

This has great significance when augmenting data for image segmentation  

### Related Issues
#23 
### PR Overview

- [y] This PR requires new unit tests [y/n] (make sure tests are included)
- [y] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date) - docstrings have been apdated
- [y] This PR is backwards compatible [y/n] - default values were chosen to preserve current behaviour
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
