### PR TITLE
docs: minor spelling fix in `.apply_transform`

### DIFF
--- a/keras_preprocessing/image.py
+++ b/keras_preprocessing/image.py
@@ -1115,7 +1115,7 @@ class ImageDataGenerator(object):
                 - `'brightness'`: Float. Brightness shift intensity.
 
         # Returns
-            A ransformed version of the input (same shape).
+            A transformed version of the input (same shape).
         """
         # x is a single image, so it doesn't have image number at index 0
         img_row_axis = self.row_axis - 1


### PR DESCRIPTION
### Summary

This PR proposes a minor spelling fix (`ransformed` --> `transformed`) in the docstring of `ImageDataGenerator.apply_transform`.

### PR Overview

- [n] This PR requires new unit tests [y/n] (make sure tests are included)
- [y] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
