### PR TITLE
Serialize text and sequence preprocessing

### DIFF
--- a/keras_preprocessing/sequence.py
+++ b/keras_preprocessing/sequence.py
@@ -323,7 +323,8 @@ class TimeseriesGenerator(keras_utils.Sequence):
                  reverse=False,
                  batch_size=128):
 
-        assert len(data) == len(targets), ('Data and targets have to be' +
+        if len(data) != len(targets): 
+            raise ValueError('Data and targets have to be' +
                ' of same length. Data length is {}'.format(len(data)) +
                ' while target length is {}'.format(len(targets)))
         
@@ -449,4 +450,4 @@ def timeseries_generator_from_json(json_string):
     targets = json.loads(config.pop('targets'))
     config['targets'] = targets
 
-    return TimeseriesGenerator(config)
+    return TimeseriesGenerator(**config)

--- a/keras_preprocessing/sequence.py
+++ b/keras_preprocessing/sequence.py
@@ -7,6 +7,7 @@ from __future__ import print_function
 
 import numpy as np
 import random
+import json
 from six.moves import range
 
 from . import get_keras_submodule
@@ -321,6 +322,11 @@ class TimeseriesGenerator(keras_utils.Sequence):
                  shuffle=False,
                  reverse=False,
                  batch_size=128):
+
+        assert len(data) == len(targets), ('Data and targets have to be' +
+               ' of same length. Data length is {}'.format(len(data)) +
+               ' while target length is {}'.format(len(targets)))
+        
         self.data = data
         self.targets = targets
         self.length = length
@@ -368,3 +374,79 @@ class TimeseriesGenerator(keras_utils.Sequence):
         if self.reverse:
             return samples[:, ::-1, ...], targets
         return samples, targets
+
+    def get_config(self):
+        '''Returns the TimeseriesGenerator configuration as Python dictionary.
+
+        # Returns
+            A Python dictionary with the TimeseriesGenerator configuration.
+        '''
+        data = self.data
+        if type(self.data).__module__ == np.__name__:
+            data = self.data.tolist()
+        try:
+            json_data = json.dumps(data)
+        except:
+            raise TypeError('Data not JSON Serializable:', data)
+
+        targets = self.targets
+        if type(self.targets).__module__ == np.__name__:
+            targets = self.targets.tolist()
+        try:
+            json_targets = json.dumps(targets)
+        except:
+            raise TypeError('Targets not JSON Serializable:', targets)
+
+        return {
+            'data': json_data,
+            'targets': json_targets,
+            'length': self.length,
+            'sampling_rate': self.sampling_rate,
+            'stride': self.stride,
+            'start_index': self.start_index,
+            'end_index': self.end_index,
+            'shuffle': self.shuffle,
+            'reverse': self.reverse,
+            'batch_size': self.batch_size
+        }
+
+    def to_json(self, **kwargs):
+        """Returns a JSON string containing the timeseries generator 
+        configuration. To load a generator from a JSON string, use
+        `keras.preprocessing.sequence.timeseries_generator_from_json(json_string)`.
+
+        # Arguments
+            **kwargs: Additional keyword arguments
+                to be passed to `json.dumps()`.
+
+        # Returns
+            A JSON string containing the tokenizer configuration.
+        """
+        config = self.get_config()
+        timeseries_generator_config = {
+            'class_name': self.__class__.__name__,
+            'config': config
+        }
+        return json.dumps(timeseries_generator_config, **kwargs)
+
+
+def timeseries_generator_from_json(json_string):
+    """Parses a JSON timeseries generator configuration file and 
+    returns a timeseries generator instance.
+
+    # Arguments
+        json_string: JSON string encoding a timeseries 
+            generator configuration.
+
+    # Returns
+        A Keras TimeseriesGenerator instance
+    """
+    full_config = json.loads(json_string)
+    config = full_config.get('config')
+
+    data = json.loads(config.pop('data'))
+    config['data'] = data
+    targets = json.loads(config.pop('targets'))
+    config['targets'] = targets
+
+    return TimeseriesGenerator(config)

--- a/keras_preprocessing/sequence.py
+++ b/keras_preprocessing/sequence.py
@@ -214,7 +214,7 @@ def skipgrams(sequence, vocabulary_size,
         random.shuffle(words)
 
         couples += [[words[i % len(words)],
-                    random.randint(1, vocabulary_size - 1)]
+                     random.randint(1, vocabulary_size - 1)]
                     for i in range(num_negative_samples)]
         if categorical:
             labels += [[1, 0]] * num_negative_samples
@@ -323,11 +323,11 @@ class TimeseriesGenerator(keras_utils.Sequence):
                  reverse=False,
                  batch_size=128):
 
-        if len(data) != len(targets): 
+        if len(data) != len(targets):
             raise ValueError('Data and targets have to be' +
-               ' of same length. Data length is {}'.format(len(data)) +
-               ' while target length is {}'.format(len(targets)))
-        
+                             ' of same length. Data length is {}'.format(len(data)) +
+                             ' while target length is {}'.format(len(targets)))
+
         self.data = data
         self.targets = targets
         self.length = length

--- a/keras_preprocessing/sequence.py
+++ b/keras_preprocessing/sequence.py
@@ -412,7 +412,7 @@ class TimeseriesGenerator(keras_utils.Sequence):
         }
 
     def to_json(self, **kwargs):
-        """Returns a JSON string containing the timeseries generator 
+        """Returns a JSON string containing the timeseries generator
         configuration. To load a generator from a JSON string, use
         `keras.preprocessing.sequence.timeseries_generator_from_json(json_string)`.
 
@@ -432,11 +432,11 @@ class TimeseriesGenerator(keras_utils.Sequence):
 
 
 def timeseries_generator_from_json(json_string):
-    """Parses a JSON timeseries generator configuration file and 
+    """Parses a JSON timeseries generator configuration file and
     returns a timeseries generator instance.
 
     # Arguments
-        json_string: JSON string encoding a timeseries 
+        json_string: JSON string encoding a timeseries
             generator configuration.
 
     # Returns

--- a/keras_preprocessing/text.py
+++ b/keras_preprocessing/text.py
@@ -458,7 +458,7 @@ class Tokenizer(object):
             'index_docs': json_index_docs
         }
 
-    def to_json(self):
+    def to_json(self, **kwargs):
         """Returns a JSON string containing the tokenizer configuration.
         To load a tokenizer from a JSON string, use
         `keras.preprocessing.text.tokenizer_from_json(json_string)`.
@@ -475,7 +475,7 @@ class Tokenizer(object):
             'class_name': self.__class__.__name__,
             'config': config
         }
-        return json.dumps(tokenizer_config)
+        return json.dumps(tokenizer_config, **kwargs)
 
 
 def tokenizer_from_json(json_string):

--- a/keras_preprocessing/text.py
+++ b/keras_preprocessing/text.py
@@ -501,9 +501,9 @@ def tokenizer_from_json(json_string):
     word_docs = json.loads(config.pop('word_docs'))
     index_docs = json.loads(config.pop('index_docs'))
     # Integer indexing gets converted to strings with json.dumps()
-    index_docs = {int(k):v for k,v in index_docs.items()}
+    index_docs = {int(k): v for k, v in index_docs.items()}
     index_word = json.loads(config.pop('index_word'))
-    index_word = {int(k):v for k,v in index_word.items()}
+    index_word = {int(k): v for k, v in index_word.items()}
     word_index = json.loads(config.pop('word_index'))
 
     tokenizer = Tokenizer(**config)

--- a/keras_preprocessing/text.py
+++ b/keras_preprocessing/text.py
@@ -170,7 +170,7 @@ class Tokenizer(object):
                  split=' ',
                  char_level=False,
                  oov_token=None,
-                 document_count = 0,
+                 document_count=0,
                  **kwargs):
         # Legacy support
         if 'nb_words' in kwargs:

--- a/keras_preprocessing/text.py
+++ b/keras_preprocessing/text.py
@@ -190,6 +190,8 @@ class Tokenizer(object):
         self.char_level = char_level
         self.oov_token = oov_token
         self.index_docs = defaultdict(int)
+        self.word_index = dict()
+        self.index_word = dict()
 
     def fit_on_texts(self, texts):
         """Updates internal vocabulary based on a list of texts.
@@ -444,6 +446,8 @@ class Tokenizer(object):
         json_word_counts = json.dumps(self.word_counts)
         json_word_docs = json.dumps(self.word_docs)
         json_index_docs = json.dumps(self.index_docs)
+        json_word_index = json.dumps(self.word_index)
+        json_index_word = json.dumps(self.index_word)
 
         return {
             'num_words': self.num_words,
@@ -455,7 +459,9 @@ class Tokenizer(object):
             'document_count': self.document_count,
             'word_counts': json_word_counts,
             'word_docs': json_word_docs,
-            'index_docs': json_index_docs
+            'index_docs': json_index_docs,
+            'index_word': json_index_word,
+            'word_index': json_word_index
         }
 
     def to_json(self, **kwargs):
@@ -494,10 +500,14 @@ def tokenizer_from_json(json_string):
     word_counts = json.loads(config.pop('word_counts'))
     word_docs = json.loads(config.pop('word_docs'))
     index_docs = json.loads(config.pop('index_docs'))
+    index_word = json.loads(config.pop('index_word'))
+    word_index = json.loads(config.pop('word_index'))
 
-    tokenizer = Tokenizer(config)
+    tokenizer = Tokenizer(**config)
     tokenizer.word_counts = word_counts
     tokenizer.word_docs = word_docs
     tokenizer.index_docs = index_docs
+    tokenizer.word_index = word_index
+    tokenizer.index_word = index_word
 
     return tokenizer

--- a/keras_preprocessing/text.py
+++ b/keras_preprocessing/text.py
@@ -500,7 +500,10 @@ def tokenizer_from_json(json_string):
     word_counts = json.loads(config.pop('word_counts'))
     word_docs = json.loads(config.pop('word_docs'))
     index_docs = json.loads(config.pop('index_docs'))
+    # Integer indexing gets converted to strings with json.dumps()
+    index_docs = {int(k):v for k,v in index_docs.items()}
     index_word = json.loads(config.pop('index_word'))
+    index_word = {int(k):v for k,v in index_word.items()}
     word_index = json.loads(config.pop('word_index'))
 
     tokenizer = Tokenizer(**config)

--- a/keras_preprocessing/text.py
+++ b/keras_preprocessing/text.py
@@ -479,7 +479,7 @@ class Tokenizer(object):
 
 
 def tokenizer_from_json(json_string):
-    """Parses a JSON tokenizer configuration file and returns a 
+    """Parses a JSON tokenizer configuration file and returns a
     tokenizer instance.
 
     # Arguments

--- a/keras_preprocessing/text.py
+++ b/keras_preprocessing/text.py
@@ -11,6 +11,7 @@ import warnings
 from collections import OrderedDict
 from collections import defaultdict
 from hashlib import md5
+import json
 
 import numpy as np
 from six.moves import range
@@ -169,6 +170,7 @@ class Tokenizer(object):
                  split=' ',
                  char_level=False,
                  oov_token=None,
+                 document_count = 0,
                  **kwargs):
         # Legacy support
         if 'nb_words' in kwargs:
@@ -184,7 +186,7 @@ class Tokenizer(object):
         self.split = split
         self.lower = lower
         self.num_words = num_words
-        self.document_count = 0
+        self.document_count = document_count
         self.char_level = char_level
         self.oov_token = oov_token
         self.index_docs = defaultdict(int)
@@ -429,3 +431,73 @@ class Tokenizer(object):
                 else:
                     raise ValueError('Unknown vectorization mode:', mode)
         return x
+
+    def get_config(self):
+        '''Returns the tokenizer configuration as Python dictionary.
+        The word count dictionaries used by the tokenizer get serialized
+        into plain JSON, so that the configuration can be read by other
+        projects.
+
+        # Returns
+            A Python dictionary with the tokenizer configuration.
+        '''
+        json_word_counts = json.dumps(self.word_counts)
+        json_word_docs = json.dumps(self.word_docs)
+        json_index_docs = json.dumps(self.index_docs)
+
+        return {
+            'num_words': self.num_words,
+            'filters': self.filters,
+            'lower': self.lower,
+            'split': self.split,
+            'char_level': self.char_level,
+            'oov_token': self.oov_token,
+            'document_count': self.document_count,
+            'word_counts': json_word_counts,
+            'word_docs': json_word_docs,
+            'index_docs': json_index_docs
+        }
+
+    def to_json(self):
+        """Returns a JSON string containing the tokenizer configuration.
+        To load a tokenizer from a JSON string, use
+        `keras.preprocessing.text.tokenizer_from_json(json_string)`.
+
+        # Arguments
+            **kwargs: Additional keyword arguments
+                to be passed to `json.dumps()`.
+
+        # Returns
+            A JSON string containing the tokenizer configuration.
+        """
+        config = self.get_config()
+        tokenizer_config = {
+            'class_name': self.__class__.__name__,
+            'config': config
+        }
+        return json.dumps(tokenizer_config)
+
+
+def tokenizer_from_json(json_string):
+    """Parses a JSON tokenizer configuration file and returns a 
+    tokenizer instance.
+
+    # Arguments
+        json_string: JSON string encoding a tokenizer configuration.
+
+    # Returns
+        A Keras Tokenizer instance
+    """
+    tokenizer_config = json.loads(json_string)
+    config = tokenizer_config.get('config')
+
+    word_counts = json.loads(config.pop('word_counts'))
+    word_docs = json.loads(config.pop('word_docs'))
+    index_docs = json.loads(config.pop('index_docs'))
+
+    tokenizer = Tokenizer(config)
+    tokenizer.word_counts = word_counts
+    tokenizer.word_docs = word_docs
+    tokenizer.index_docs = index_docs
+
+    return tokenizer

--- a/tests/sequence_test.py
+++ b/tests/sequence_test.py
@@ -103,6 +103,18 @@ def test_remove_long_seq():
     assert new_label == ['a']
 
 
+def test_TimeseriesGenerator_serde():
+    data = np.array([[i] for i in range(50)])
+    targets = np.array([[i] for i in range(50)])
+
+    data_gen = sequence.TimeseriesGenerator(data, targets,
+                                            length=10,
+                                            sampling_rate=2,
+                                            batch_size=2)
+    json_gen = data_gen.to_json()
+    recovered_gen = sequence.timeseries_generator_from_json(json_gen)
+
+
 def test_TimeseriesGenerator():
     data = np.array([[i] for i in range(50)])
     targets = np.array([[i] for i in range(50)])

--- a/tests/sequence_test.py
+++ b/tests/sequence_test.py
@@ -114,6 +114,19 @@ def test_TimeseriesGenerator_serde():
     json_gen = data_gen.to_json()
     recovered_gen = sequence.timeseries_generator_from_json(json_gen)
 
+    assert data_gen.batch_size == recovered_gen.batch_size
+    assert data_gen.end_index == recovered_gen.end_index
+    assert data_gen.length == recovered_gen.length
+    assert data_gen.reverse == recovered_gen.reverse
+    assert data_gen.sampling_rate == recovered_gen.sampling_rate
+    assert data_gen.shuffle == recovered_gen.shuffle
+    assert data_gen.start_index == data_gen.start_index
+    assert data_gen.stride == data_gen.stride
+
+
+    assert (data_gen.data == recovered_gen.data).all()
+    assert (data_gen.targets == recovered_gen.targets).all()
+
 
 def test_TimeseriesGenerator():
     data = np.array([[i] for i in range(50)])

--- a/tests/sequence_test.py
+++ b/tests/sequence_test.py
@@ -123,7 +123,6 @@ def test_TimeseriesGenerator_serde():
     assert data_gen.start_index == data_gen.start_index
     assert data_gen.stride == data_gen.stride
 
-
     assert (data_gen.data == recovered_gen.data).all()
     assert (data_gen.targets == recovered_gen.targets).all()
 

--- a/tests/text_test.py
+++ b/tests/text_test.py
@@ -62,12 +62,7 @@ def test_tokenizer_serde_no_fitting():
     tokenizer_json = tokenizer.to_json()
     recovered = text.tokenizer_from_json(tokenizer_json)
 
-    assert tokenizer.char_level == recovered.char_level
-    assert tokenizer.document_count == recovered.document_count
-    assert tokenizer.filters == recovered.filters
-    assert tokenizer.lower == recovered.lower
-    assert tokenizer.num_words == recovered.num_words
-    assert tokenizer.oov_token == recovered.oov_token
+    assert tokenizer.get_config() == recovered.get_config()
 
     assert tokenizer.word_docs == recovered.word_docs
     assert tokenizer.word_counts == recovered.word_counts

--- a/tests/text_test.py
+++ b/tests/text_test.py
@@ -56,8 +56,28 @@ def test_tokenizer():
     for mode in ['binary', 'count', 'tfidf', 'freq']:
         matrix = tokenizer.texts_to_matrix(sample_texts, mode)
 
+def test_tokenizer_serde_no_fitting():
+    tokenizer = text.Tokenizer(num_words=100)
 
-def test_tokenizer_serde():
+    tokenizer_json = tokenizer.to_json()
+    recovered = text.tokenizer_from_json(tokenizer_json)
+
+    assert tokenizer.char_level == recovered.char_level
+    assert tokenizer.document_count == recovered.document_count
+    assert tokenizer.filters == recovered.filters
+    assert tokenizer.lower == recovered.lower
+    assert tokenizer.num_words == recovered.num_words
+    assert tokenizer.oov_token == recovered.oov_token
+
+    assert tokenizer.word_docs == recovered.word_docs
+    assert tokenizer.word_counts == recovered.word_counts
+    assert tokenizer.word_index == recovered.word_index
+    assert tokenizer.index_word == recovered.index_word
+    assert tokenizer.index_docs == recovered.index_docs
+
+
+
+def test_tokenizer_serde_fitting():
     sample_texts = [
         'There was a time that the pieces fit, but I watched them fall away',
         'Mildewed and smoldering, strangled by our coveting',
@@ -78,6 +98,12 @@ def test_tokenizer_serde():
     assert tokenizer.lower == recovered.lower
     assert tokenizer.num_words == recovered.num_words
     assert tokenizer.oov_token == recovered.oov_token
+
+    assert tokenizer.word_docs == recovered.word_docs
+    assert tokenizer.word_counts == recovered.word_counts
+    assert tokenizer.word_index == recovered.word_index
+    assert tokenizer.index_word == recovered.index_word
+    assert tokenizer.index_docs == recovered.index_docs
 
 
 def test_sequential_fit():

--- a/tests/text_test.py
+++ b/tests/text_test.py
@@ -70,7 +70,14 @@ def test_tokenizer_serde():
     tokenizer.fit_on_sequences(sequences)
 
     tokenizer_json = tokenizer.to_json()
-    recovered_tokenizer = text.tokenizer_from_json(tokenizer_json)
+    recovered = text.tokenizer_from_json(tokenizer_json)
+
+    assert tokenizer.char_level == recovered.char_level
+    assert tokenizer.document_count == recovered.document_count
+    assert tokenizer.filters == recovered.filters
+    assert tokenizer.lower == recovered.lower
+    assert tokenizer.num_words == recovered.num_words
+    assert tokenizer.oov_token == recovered.oov_token
 
 
 def test_sequential_fit():

--- a/tests/text_test.py
+++ b/tests/text_test.py
@@ -70,7 +70,7 @@ def test_tokenizer_serde():
     tokenizer.fit_on_sequences(sequences)
 
     tokenizer_json = tokenizer.to_json()
-    recovered_tokenizer =text.tokenizer_from_json(tokenizer_json)
+    recovered_tokenizer = text.tokenizer_from_json(tokenizer_json)
 
 
 def test_sequential_fit():
@@ -229,7 +229,7 @@ def test_sequences_to_texts():
     tokenizer.fit_on_texts(texts)
     tokenized_text = tokenizer.texts_to_sequences(texts)
     trans_text = tokenizer.sequences_to_texts(tokenized_text)
-    print (trans_text)
+    print(trans_text)
     assert trans_text == ['the cat sat on the mat',
                           'the dog sat on the log',
                           'dogs <unk> <unk> <unk> <unk>']
@@ -274,6 +274,7 @@ def test_tokenizer_lower_flag():
                                         ('g', 5), ('l', 2), ('i', 2), ('v', 1),
                                         ('r', 1)])
     assert char_tokenizer.word_counts == expected_word_counts
+
 
 if __name__ == '__main__':
     pytest.main([__file__])

--- a/tests/text_test.py
+++ b/tests/text_test.py
@@ -56,6 +56,7 @@ def test_tokenizer():
     for mode in ['binary', 'count', 'tfidf', 'freq']:
         matrix = tokenizer.texts_to_matrix(sample_texts, mode)
 
+
 def test_tokenizer_serde_no_fitting():
     tokenizer = text.Tokenizer(num_words=100)
 
@@ -69,7 +70,6 @@ def test_tokenizer_serde_no_fitting():
     assert tokenizer.word_index == recovered.word_index
     assert tokenizer.index_word == recovered.index_word
     assert tokenizer.index_docs == recovered.index_docs
-
 
 
 def test_tokenizer_serde_fitting():

--- a/tests/text_test.py
+++ b/tests/text_test.py
@@ -57,6 +57,22 @@ def test_tokenizer():
         matrix = tokenizer.texts_to_matrix(sample_texts, mode)
 
 
+def test_tokenizer_serde():
+    sample_texts = [
+        'There was a time that the pieces fit, but I watched them fall away',
+        'Mildewed and smoldering, strangled by our coveting',
+        'I\'ve done the math enough to know the dangers of our second guessing']
+    tokenizer = text.Tokenizer(num_words=100)
+    tokenizer.fit_on_texts(sample_texts)
+
+    seq_generator = tokenizer.texts_to_sequences_generator(sample_texts)
+    sequences = [seq for seq in seq_generator]
+    tokenizer.fit_on_sequences(sequences)
+
+    tokenizer_json = tokenizer.to_json()
+    recovered_tokenizer =text.tokenizer_from_json(tokenizer_json)
+
+
 def test_sequential_fit():
     texts = ['The cat sat on the mat.',
              'The dog sat on the log.',


### PR DESCRIPTION
### Summary

Serde for text and sequence preprocessing (will do image in a follow-up PR). Serializes objects to JSON in usual Keras-style, comes with unit tests.

Note to reviewer: Where possible we store data as plain text. This is done so that other projects (not necessarily Python) can pick up the configs and restore them. Particularly, I'll write preprocessor loaders for DL4J in Java.

Autogen docs should pick up these additions, but I'm not 100% how this works with this separate project.
---

- [x] This PR requires has unit tests
- [x] This PR requires no update to documentation
- [x] This PR is backwards compatible
- [x] This PR adds new functionality to the API
