### PR TITLE
pad_sequences: Add support for string value.

### DIFF
--- a/keras_preprocessing/sequence.py
+++ b/keras_preprocessing/sequence.py
@@ -9,6 +9,8 @@ import numpy as np
 import random
 import json
 from six.moves import range
+import six
+import warnings
 
 from . import get_keras_submodule
 
@@ -74,6 +76,13 @@ def pad_sequences(sequences, maxlen=None, dtype='int32',
         if len(s) > 0:
             sample_shape = np.asarray(s).shape[1:]
             break
+
+    if isinstance(value, six.string_types) and dtype != object \
+            and not np.issubdtype(dtype, np.str_) \
+            and not np.issubdtype(dtype, np.unicode_):
+        warnings.warn("`dtype` {} is not compatible with `value`'s type: {}\n"
+                      "You should set `dtype=object` for variable length strings."
+                      .format(dtype, type(value)))
 
     x = np.full((num_samples, maxlen) + sample_shape, value, dtype=dtype)
     for idx, s in enumerate(sequences):

--- a/keras_preprocessing/sequence.py
+++ b/keras_preprocessing/sequence.py
@@ -39,12 +39,13 @@ def pad_sequences(sequences, maxlen=None, dtype='int32',
         sequences: List of lists, where each element is a sequence.
         maxlen: Int, maximum length of all sequences.
         dtype: Type of the output sequences.
+            To pad sequences with variable length strings, you can use `object`.
         padding: String, 'pre' or 'post':
             pad either before or after each sequence.
         truncating: String, 'pre' or 'post':
             remove values from sequences larger than
             `maxlen`, either at the beginning or at the end of the sequences.
-        value: Float, padding value.
+        value: Float or String, padding value.
 
     # Returns
         x: Numpy array with shape `(len(sequences), maxlen)`
@@ -74,7 +75,7 @@ def pad_sequences(sequences, maxlen=None, dtype='int32',
             sample_shape = np.asarray(s).shape[1:]
             break
 
-    x = (np.ones((num_samples, maxlen) + sample_shape) * value).astype(dtype)
+    x = np.full((num_samples, maxlen) + sample_shape, value, dtype=dtype)
     for idx, s in enumerate(sequences):
         if not len(s):
             continue  # empty list/array was found

--- a/keras_preprocessing/sequence.py
+++ b/keras_preprocessing/sequence.py
@@ -10,7 +10,6 @@ import random
 import json
 from six.moves import range
 import six
-import warnings
 
 from . import get_keras_submodule
 
@@ -77,12 +76,11 @@ def pad_sequences(sequences, maxlen=None, dtype='int32',
             sample_shape = np.asarray(s).shape[1:]
             break
 
-    if isinstance(value, six.string_types) and dtype != object \
-            and not np.issubdtype(dtype, np.str_) \
-            and not np.issubdtype(dtype, np.unicode_):
-        warnings.warn("`dtype` {} is not compatible with `value`'s type: {}\n"
-                      "You should set `dtype=object` for variable length strings."
-                      .format(dtype, type(value)))
+    is_dtype_str = np.issubdtype(dtype, np.str_) or np.issubdtype(dtype, np.unicode_)
+    if isinstance(value, six.string_types) and dtype != object and not is_dtype_str:
+        raise ValueError("`dtype` {} is not compatible with `value`'s type: {}\n"
+                         "You should set `dtype=object` for variable length strings."
+                         .format(dtype, type(value)))
 
     x = np.full((num_samples, maxlen) + sample_shape, value, dtype=dtype)
     for idx, s in enumerate(sequences):

--- a/tests/sequence_test.py
+++ b/tests/sequence_test.py
@@ -53,7 +53,7 @@ def test_pad_sequences_str():
                                dtype='<U3')
     assert_equal(b, [['pad', '1'], ['1', '2'], ['1', '2']])
 
-    with pytest.raises(ValueError, match="`dtype` int32 is not compatible with ")
+    with pytest.raises(ValueError, match="`dtype` int32 is not compatible with "):
         sequence.pad_sequences(a, maxlen=2, truncating='post', value='pad')
 
 

--- a/tests/sequence_test.py
+++ b/tests/sequence_test.py
@@ -2,6 +2,7 @@ from math import ceil
 import pytest
 import numpy as np
 from numpy.testing import assert_allclose
+from numpy.testing import assert_equal
 from numpy.testing import assert_raises
 
 import keras
@@ -33,6 +34,24 @@ def test_pad_sequences():
     # test value
     b = sequence.pad_sequences(a, maxlen=3, value=1)
     assert_allclose(b, [[1, 1, 1], [1, 1, 2], [1, 2, 3]])
+
+
+def test_pad_sequences_str():
+    a = [['1'], ['1', '2'], ['1', '2', '3']]
+
+    # test padding
+    b = sequence.pad_sequences(a, maxlen=3, padding='pre', value='pad', dtype=object)
+    assert_equal(b, [['pad', 'pad', '1'], ['pad', '1', '2'], ['1', '2', '3']])
+    b = sequence.pad_sequences(a, maxlen=3, padding='post', value='pad', dtype='<U3')
+    assert_equal(b, [['1', 'pad', 'pad'], ['1', '2', 'pad'], ['1', '2', '3']])
+
+    # test truncating
+    b = sequence.pad_sequences(a, maxlen=2, truncating='pre', value='pad',
+                               dtype=object)
+    assert_equal(b, [['pad', '1'], ['1', '2'], ['2', '3']])
+    b = sequence.pad_sequences(a, maxlen=2, truncating='post', value='pad',
+                               dtype='<U3')
+    assert_equal(b, [['pad', '1'], ['1', '2'], ['1', '2']])
 
 
 def test_pad_sequences_vector():

--- a/tests/sequence_test.py
+++ b/tests/sequence_test.py
@@ -53,6 +53,15 @@ def test_pad_sequences_str():
                                dtype='<U3')
     assert_equal(b, [['pad', '1'], ['1', '2'], ['1', '2']])
 
+    try:
+        sequence.pad_sequences(a, maxlen=2, truncating='post', value='pad')
+        raise Exception("Should throw an exception about invalid dtype.")
+    except ValueError as err:
+        assert err.args == ("`dtype` int32 is not compatible with"
+                            " `value`'s type: <class 'str'>"
+                            "\nYou should set `dtype=object`"
+                            " for variable length strings.",)
+
 
 def test_pad_sequences_vector():
     a = [[[1, 1]],

--- a/tests/sequence_test.py
+++ b/tests/sequence_test.py
@@ -53,14 +53,8 @@ def test_pad_sequences_str():
                                dtype='<U3')
     assert_equal(b, [['pad', '1'], ['1', '2'], ['1', '2']])
 
-    try:
+    with pytest.raises(ValueError, match="`dtype` int32 is not compatible with ")
         sequence.pad_sequences(a, maxlen=2, truncating='post', value='pad')
-        raise Exception("Should throw an exception about invalid dtype.")
-    except ValueError as err:
-        assert err.args == ("`dtype` int32 is not compatible with"
-                            " `value`'s type: <class 'str'>"
-                            "\nYou should set `dtype=object`"
-                            " for variable length strings.",)
 
 
 def test_pad_sequences_vector():


### PR DESCRIPTION
### Summary
Add support for `value` parameter as a string to `pad_sequences`.

### Related Issues

### PR Overview

- [x] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n] 
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
