### PR TITLE
Update markdown in text.py for documentation

### DIFF
--- a/keras_preprocessing/text.py
+++ b/keras_preprocessing/text.py
@@ -31,7 +31,7 @@ def text_to_word_sequence(text,
     # Arguments
         text: Input text (string).
         filters: list (or concatenation) of characters to filter out, such as
-            punctuation. Default: `!"#$%&()*+,-./:;<=>?@[\\]^_`{|}~\t\n`,
+            punctuation. Default: ``!"#$%&()*+,-./:;<=>?@[\\]^_`{|}~\t\n``,
             includes basic punctuation, tabs, and newlines.
         lower: boolean. Whether to convert the input to lowercase.
         split: str. Separator for word splitting.
@@ -74,7 +74,7 @@ def one_hot(text, n,
         text: Input text (string).
         n: int. Size of vocabulary.
         filters: list (or concatenation) of characters to filter out, such as
-            punctuation. Default: `!"#$%&()*+,-./:;<=>?@[\\]^_`{|}~\t\n`,
+            punctuation. Default: ``!"#$%&()*+,-./:;<=>?@[\\]^_`{|}~\t\n``,
             includes basic punctuation, tabs, and newlines.
         lower: boolean. Whether to set the text to lowercase.
         split: str. Separator for word splitting.
@@ -106,7 +106,7 @@ def hashing_trick(text, n,
             it is not consistent across different runs, while 'md5'
             is a stable hashing function.
         filters: list (or concatenation) of characters to filter out, such as
-            punctuation. Default: `!"#$%&()*+,-./:;<=>?@[\\]^_`{|}~\t\n`,
+            punctuation. Default: ``!"#$%&()*+,-./:;<=>?@[\\]^_`{|}~\t\n``,
             includes basic punctuation, tabs, and newlines.
         lower: boolean. Whether to set the text to lowercase.
         split: str. Separator for word splitting.


### PR DESCRIPTION
### Summary
Currently the documentation on https://keras.io/preprocessing/text/ is breaking when trying to display the `` ` `` character in the default filter. 
![screen shot 2018-08-16 at 2 38 34 pm](https://user-images.githubusercontent.com/3277288/44212767-2129f700-a164-11e8-8dd7-4409bf3336f5.png)

Wrapping in additional backticks fixes this in markdown.

### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
