### PR TITLE
Ensure that ImageDataGenerator.flow() generates stratified training a…

### DIFF
--- a/keras_preprocessing/image.py
+++ b/keras_preprocessing/image.py
@@ -1554,6 +1554,13 @@ class NumpyArrayIterator(Iterator):
                 raise ValueError('Invalid subset name:', subset,
                                  '; expected "training" or "validation".')
             split_idx = int(len(x) * image_data_generator._validation_split)
+
+            # in case the numpy arrays are sorted by class, we need to shuffle them,
+            # to ensure that both training and test set will get a stratified sample
+            permutation_idx = np.random.permutation(len(x))
+            x = x[permutation_idx]
+            y = y[permutation_idx]
+
             if subset == 'validation':
                 x = x[:split_idx]
                 x_misc = [np.asarray(xx[:split_idx]) for xx in x_misc]

--- a/tests/image_test.py
+++ b/tests/image_test.py
@@ -199,18 +199,19 @@ class TestImage(object):
             for im in test_images:
                 img_list.append(image.img_to_array(im)[None, ...])
 
-            images = np.vstack(img_list)
+            images = np.repeat(np.vstack(img_list), 1000, 0)
+            labels = np.concatenate([np.zeros((len(images)/2,)), np.ones((len(images)/2,))])
             generator = image.ImageDataGenerator(validation_split=0.5)
-            seq = generator.flow(images, np.arange(images.shape[0]),
-                                 shuffle=False, batch_size=3,
+            seq = generator.flow(images, labels,
+                                 shuffle=False, batch_size=100,
                                  subset='validation')
             x, y = seq[0]
-            assert list(y) == [0, 1, 2]
-            seq = generator.flow(images, np.arange(images.shape[0]),
-                                 shuffle=False, batch_size=3,
+            assert 40 <= sum(y) <= 60   # ideally 50%
+            seq = generator.flow(images, labels,
+                                 shuffle=False, batch_size=100,
                                  subset='training')
             x2, y2 = seq[0]
-            assert list(y2) == [4, 5, 6]
+            assert 40 <= sum(y2) <= 60  # ideally 50%
 
             with pytest.raises(ValueError):
                 generator.flow(images, np.arange(images.shape[0]),
@@ -914,7 +915,6 @@ class TestImage(object):
         with pytest.raises(ValueError):
             loaded_im = image.load_img(filename_rgb, target_size=(25, 25),
                                        interpolation="unsupported")
-
 
 if __name__ == '__main__':
     pytest.main([__file__])


### PR DESCRIPTION
…nd test sets even if the passed numpy arrays are sorted by class

### Summary
A small improvement that fixes a problem that could take days to debug. 

In case the initial numpy arrays used for ImageDataGenerator.flow() are sorted by class, which can be the case if the user's code is reading images class by class, there is a high chance that the class frequencies in the resulting training and tests will differ. In the worst case, the training set will contain only samples of one class and the test set samples of another class, which would lead to poor model generalization.

The proposed patch fixes the problem by shuffling numpy arrays before they are split into training and validation.

### Related Issues
The issue happened to me at work. I've fixed it rather than opening an issue.

### PR Overview

- [n] This PR requires new unit tests [y/n] (make sure tests are included) (OLD TEST EXTENDED TO COVER THE FIX)
- [n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
