### PR TITLE
Fix Tokenizer.texts_to_sequences to use a maximum of Tokenizer.num_words words

### DIFF
--- a/keras_preprocessing/text.py
+++ b/keras_preprocessing/text.py
@@ -311,7 +311,7 @@ class Tokenizer(object):
             for w in seq:
                 i = self.word_index.get(w)
                 if i is not None:
-                    if num_words and i >= num_words:
+                    if num_words and i > num_words:
                         if oov_token_index is not None:
                             vect.append(oov_token_index)
                     else:

--- a/tests/text_test.py
+++ b/tests/text_test.py
@@ -48,7 +48,7 @@ def test_tokenizer():
     sequences = []
     for seq in tokenizer.texts_to_sequences_generator(sample_texts):
         sequences.append(seq)
-    assert np.max(np.max(sequences)) < 10
+    assert np.max(np.max(sequences)) <= 10
     assert np.min(np.min(sequences)) == 1
 
     tokenizer.fit_on_sequences(sequences)
@@ -181,7 +181,7 @@ def test_tokenizer_oov_flag_and_num_words():
     x_test_seq = tokenizer.texts_to_sequences(x_test)
     trans_text = ' '.join(tokenizer.index_word[t] for t in x_test_seq[0])
     assert len(x_test_seq[0]) == 6
-    assert trans_text == 'this <unk> <unk> <unk> <unk> <unk>'
+    assert trans_text == 'this text <unk> <unk> <unk> <unk>'
 
 
 def test_tokenizer_oov_flag_and_num_words():
@@ -194,7 +194,7 @@ def test_tokenizer_oov_flag_and_num_words():
     x_test_seq = tokenizer.texts_to_sequences(x_test)
     trans_text = ' '.join(tokenizer.index_word[t] for t in x_test_seq[0])
     assert len(x_test_seq[0]) == 6
-    assert trans_text == 'this <unk> <unk> <unk> <unk> <unk>'
+    assert trans_text == 'this text <unk> <unk> <unk> <unk>'
 
 
 def test_sequences_to_texts_with_num_words_and_oov_token():


### PR DESCRIPTION
### Summary
`Tokenizer.texts_to_sequences` was only using `Tokenizer.num_words - 1` words. Now it uses `Tokenizer.num_words` words.

### Related Issues
#52 
### PR Overview

- [ ] This PR requires new unit tests [y/n]
- [ ] This PR requires to update the documentation [y/n]
- [ ] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n]