### PR TITLE
Use Sequence if available

### DIFF
--- a/keras_preprocessing/image.py
+++ b/keras_preprocessing/image.py
@@ -12,6 +12,12 @@ import threading
 import warnings
 import multiprocessing.pool
 from functools import partial
+from keras_preprocessing import get_keras_submodule
+
+try:
+    IteratorType = get_keras_submodule('utils').Sequence
+except ImportError:
+    IteratorType = object
 
 try:
     from PIL import ImageEnhance
@@ -1391,7 +1397,7 @@ class ImageDataGenerator(object):
             self.principal_components = (u * s_inv).dot(u.T)
 
 
-class Iterator(object):
+class Iterator(IteratorType):
     """Base class for image data iterators.
 
     Every `Iterator` must implement the `_get_batches_of_transformed_samples`


### PR DESCRIPTION
### Summary
In a previous PR we removed the parent type of Iterator which is important when using the Iterator object with Keras. (*_generator especially).

This sets the Iterator type if possible.


### Related Issues
Fixes https://github.com/keras-team/keras-preprocessing/issues/51
### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
