### PR TITLE
Fix small typeerror bug in flow_from_dataframe when y_col is str and class_mode is "other"

### DIFF
--- a/keras_preprocessing/image.py
+++ b/keras_preprocessing/image.py
@@ -2148,6 +2148,8 @@ class DataFrameIterator(Iterator):
             self.classes = np.array([self.class_indices[cls] for cls in classes])
         elif class_mode == "other":
             self.data = self.df[y_col].values
+            if type(y_col) == str:
+                y_col = [y_col]
             if "object" in list(self.df[y_col].dtypes):
                 raise TypeError("y_col column/s must be numeric datatypes.")
         self.filenames = filenames

--- a/tests/image_test.py
+++ b/tests/image_test.py
@@ -492,6 +492,10 @@ class TestImage(object):
             df_multiple_y_iterator = generator.flow_from_dataframe(
                 df_regression, str(tmpdir), y_col=["col1", "col2"],
                 has_ext=True, class_mode="other")
+        with pytest.raises(TypeError):
+            df_single_y_iterator = generator.flow_from_dataframe(
+                df_regression, str(tmpdir), y_col="col1",
+                has_ext=True, class_mode="other")
         # check number of classes and images
         assert len(df_iterator.class_indices) == num_classes
         assert len(df_iterator.classes) == count


### PR DESCRIPTION
### Summary

### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [ ] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
