### PR TITLE
Escape tabs and newlines in docstring

### DIFF
--- a/keras_preprocessing/text.py
+++ b/keras_preprocessing/text.py
@@ -31,7 +31,7 @@ def text_to_word_sequence(text,
     # Arguments
         text: Input text (string).
         filters: list (or concatenation) of characters to filter out, such as
-            punctuation. Default: ``!"#$%&()*+,-./:;<=>?@[\\]^_`{|}~\t\n``,
+            punctuation. Default: ``!"#$%&()*+,-./:;<=>?@[\\]^_`{|}~\\t\\n``,
             includes basic punctuation, tabs, and newlines.
         lower: boolean. Whether to convert the input to lowercase.
         split: str. Separator for word splitting.
@@ -74,7 +74,7 @@ def one_hot(text, n,
         text: Input text (string).
         n: int. Size of vocabulary.
         filters: list (or concatenation) of characters to filter out, such as
-            punctuation. Default: ``!"#$%&()*+,-./:;<=>?@[\\]^_`{|}~\t\n``,
+            punctuation. Default: ``!"#$%&()*+,-./:;<=>?@[\\]^_`{|}~\\t\\n``,
             includes basic punctuation, tabs, and newlines.
         lower: boolean. Whether to set the text to lowercase.
         split: str. Separator for word splitting.
@@ -106,7 +106,7 @@ def hashing_trick(text, n,
             it is not consistent across different runs, while 'md5'
             is a stable hashing function.
         filters: list (or concatenation) of characters to filter out, such as
-            punctuation. Default: ``!"#$%&()*+,-./:;<=>?@[\\]^_`{|}~\t\n``,
+            punctuation. Default: ``!"#$%&()*+,-./:;<=>?@[\\]^_`{|}~\\t\\n``,
             includes basic punctuation, tabs, and newlines.
         lower: boolean. Whether to set the text to lowercase.
         split: str. Separator for word splitting.


### PR DESCRIPTION
### Summary
Unescaped tabs and newlines in docstring cause the document being rendered improperly.
<img width="841" alt="image" src="https://user-images.githubusercontent.com/1214890/46581966-c1075100-ca40-11e8-83e5-4ea230f63018.png">


### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [ ] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)