### PR TITLE
Fix a bug in DataFrameIterator ext_exist check

### DIFF
--- a/keras_preprocessing/image.py
+++ b/keras_preprocessing/image.py
@@ -2096,7 +2096,7 @@ class DataFrameIterator(Iterator):
         if has_ext:
             ext_exist = False
             for ext in white_list_formats:
-                if self.df.loc[0, x_col].endswith("." + ext):
+                if self.df[x_col].values[0].endswith("." + ext):
                     ext_exist = True
                     break
             if not ext_exist:

--- a/tests/image_test.py
+++ b/tests/image_test.py
@@ -479,7 +479,8 @@ class TestImage(object):
                 count += 1
 
         df = pd.DataFrame({"filename": filenames,
-                           "class": [random.randint(0, 1) for _ in filenames]})
+                           "class": [random.randint(0, 1) for _ in filenames]},
+                           index=np.arange(1,len(filenames)+1))
 
         # create iterator
         generator = image.ImageDataGenerator()

--- a/tests/image_test.py
+++ b/tests/image_test.py
@@ -480,7 +480,7 @@ class TestImage(object):
 
         df = pd.DataFrame({"filename": filenames,
                            "class": [random.randint(0, 1) for _ in filenames]},
-                           index=np.arange(1,len(filenames)+1))
+                          index=np.arange(1, len(filenames) + 1))
 
         # create iterator
         generator = image.ImageDataGenerator()


### PR DESCRIPTION
### Summary

Fix ext_exits check error with dataframes without 0-index.

### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
