### PR TITLE
Fix "DataFrameIterator is regardless of x_col" bug

### DIFF
--- a/keras_preprocessing/image.py
+++ b/keras_preprocessing/image.py
@@ -2102,26 +2102,17 @@ class DataFrameIterator(Iterator):
             if not ext_exist:
                 raise ValueError('has_ext is set to True but'
                                  ' extension not found in x_col')
-            temp_df = pd.DataFrame({x_col: filenames}, dtype=str)
-            temp_df = self.df.merge(temp_df, how='right', on=x_col)
-            temp_df = temp_df.set_index(x_col)
-            temp_df = temp_df.reindex(filenames)
-            temp_df = temp_df.dropna()
-            self.filenames = list(temp_df.index)
+            self.df = self.df[self.df[x_col].isin(filenames)]
+            self.filenames = list(self.df[x_col])
         else:
             without_ext_with = {f[:-1 * (len(f.split(".")[-1]) + 1)]: f
                                 for f in filenames}
             filenames_without_ext = [f[:-1 * (len(f.split(".")[-1]) + 1)]
                                      for f in filenames]
-            temp_df = pd.DataFrame({x_col: filenames_without_ext}, dtype=str)
-            temp_df = self.df.merge(temp_df, how='right', on=x_col)
-            temp_df = temp_df.set_index(x_col)
-            temp_df = temp_df.reindex(filenames_without_ext)
-            temp_df = temp_df.dropna()
-            self.filenames = [without_ext_with[f] for f in temp_df.index]
-        self.df = temp_df.copy()
+            self.df = self.df[self.df[x_col].isin(filenames_without_ext)]
+            self.filenames = [without_ext_with[f] for f in list(self.df[x_col])]
         if class_mode not in ["other", "input", None]:
-            classes = temp_df[y_col].values
+            classes = self.df[y_col].values
             self.classes = np.array([self.class_indices[cls] for cls in classes])
         elif class_mode == "other":
             self.data = self.df[y_col].values

--- a/keras_preprocessing/image.py
+++ b/keras_preprocessing/image.py
@@ -2102,14 +2102,15 @@ class DataFrameIterator(Iterator):
             if not ext_exist:
                 raise ValueError('has_ext is set to True but'
                                  ' extension not found in x_col')
-            self.df = self.df[self.df[x_col].isin(filenames)]
+            self.df = self.df[self.df[x_col].isin(filenames)].sort_values(by=x_col)
             self.filenames = list(self.df[x_col])
         else:
             without_ext_with = {f[:-1 * (len(f.split(".")[-1]) + 1)]: f
                                 for f in filenames}
             filenames_without_ext = [f[:-1 * (len(f.split(".")[-1]) + 1)]
                                      for f in filenames]
-            self.df = self.df[self.df[x_col].isin(filenames_without_ext)]
+            self.df = (self.df[self.df[x_col].isin(filenames_without_ext)]
+                       .sort_values(by=x_col))
             self.filenames = [without_ext_with[f] for f in list(self.df[x_col])]
         if class_mode not in ["other", "input", None]:
             classes = self.df[y_col].values

--- a/tests/image_test.py
+++ b/tests/image_test.py
@@ -573,9 +573,8 @@ class TestImage(object):
         filenames = []
         for test_images in self.all_test_images:
             for im in test_images:
-                filename = str(
-                    tmpdir / 'image-{}.png'.format(count))
-                im.save(filename)
+                filename = 'image-{}.png'.format(count)
+                im.save(str(tmpdir / filename))
                 filenames.append(filename)
                 count += 1
         df = pd.DataFrame({"filename": filenames})
@@ -724,6 +723,39 @@ class TestImage(object):
             assert np.array_equal(a1, a3)
             assert np.array_equal(c1, c2)
             assert np.array_equal(c1, c3)
+
+    def test_dataframe_iterator_n(self, tmpdir):
+
+        # save the images in the tmpdir
+        count = 0
+        filenames = []
+        for test_images in self.all_test_images:
+            for im in test_images:
+                filename = "image-{}.png".format(count)
+                filenames.append(filename)
+                im.save(str(tmpdir / filename))
+                count += 1
+
+        # exclude first two items
+        n_files = len(filenames)
+        input_filenames = filenames[2:]
+
+        # create dataframes
+        classes = np.random.randint(2, size=len(input_filenames))
+        df = pd.DataFrame({"filename": input_filenames})
+        df2 = pd.DataFrame({"filename": input_filenames,
+                            "class": classes})
+
+        # create iterators
+        generator = image.ImageDataGenerator()
+        df_iterator = generator.flow_from_dataframe(
+            df, str(tmpdir), has_ext=True, class_mode=None)
+        df2_iterator = generator.flow_from_dataframe(
+            df2, str(tmpdir), has_ext=True, class_mode='binary')
+
+        # Test the number of items in iterators
+        assert df_iterator.n == n_files - 2
+        assert df2_iterator.n == n_files - 2
 
     def test_img_utils(self):
         height, width = 10, 8


### PR DESCRIPTION
### Summary

- "DataFrameIterator is regardless of x_col" issue (#60) still apears when the input dataframe has only one column(filename column).
  This PR fixes this issue and adds a test.
- This PR also fixes a bug in test_dataframe_iterator_class_mode_input.
  (The current API passes this test because of the previous bug.)


### Related Issues

#60, #61

### PR Overview

- [x] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
