### PR TITLE
Fix num_words check in tokenizers

### DIFF
--- a/keras_preprocessing/text.py
+++ b/keras_preprocessing/text.py
@@ -311,7 +311,7 @@ class Tokenizer(object):
             for w in seq:
                 i = self.word_index.get(w)
                 if i is not None:
-                    if num_words and i >= num_words:
+                    if num_words and i > num_words:
                         if oov_token_index is not None:
                             vect.append(oov_token_index)
                     else:
@@ -356,7 +356,7 @@ class Tokenizer(object):
             for num in seq:
                 word = self.index_word.get(num)
                 if word is not None:
-                    if num_words and num >= num_words:
+                    if num_words and num > num_words:
                         if oov_token_index is not None:
                             vect.append(self.index_word[oov_token_index])
                     else:
@@ -396,7 +396,7 @@ class Tokenizer(object):
         """
         if not self.num_words:
             if self.word_index:
-                num_words = len(self.word_index) + 1
+                num_words = len(self.word_index)
             else:
                 raise ValueError('Specify a dimension (num_words argument), '
                                  'or fit on some text data first.')
@@ -413,7 +413,7 @@ class Tokenizer(object):
                 continue
             counts = defaultdict(int)
             for j in seq:
-                if j >= num_words:
+                if j > num_words:
                     continue
                 counts[j] += 1
             for j, c in list(counts.items()):


### PR DESCRIPTION
### Summary

The current implementation only keeps `num_words-1` most frequent words, not `num_words` as suggested in the docs, because index 0 is reserved and never assigned to an existing word. 

### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
