### PR TITLE
Fix off-by-one error if num_words is not set explicitly 

### DIFF
--- a/keras_preprocessing/text.py
+++ b/keras_preprocessing/text.py
@@ -396,7 +396,7 @@ class Tokenizer(object):
         """
         if not self.num_words:
             if self.word_index:
-                num_words = len(self.word_index) + 1
+                num_words = len(self.word_index)
             else:
                 raise ValueError('Specify a dimension (num_words argument), '
                                  'or fit on some text data first.')


### PR DESCRIPTION
### Summary
When num_words is not set explicitly on initialization of the tokenizer it is calculated on basis of the length of the dictionary when sequences_to_matrix is called. However, num_words is off by one because 1 is added to the length of the dict ( e.g. if the tokenizer is fit on the text  "car bike plane", the num_words equals 4 instead of 3).

### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [X] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
