### PR TITLE
Add sort and drop_duplicates option to DataFrameIterator

### DIFF
--- a/keras_preprocessing/image.py
+++ b/keras_preprocessing/image.py
@@ -1027,7 +1027,9 @@ class ImageDataGenerator(object):
                             save_prefix='',
                             save_format='png',
                             subset=None,
-                            interpolation='nearest'):
+                            interpolation='nearest',
+                            sort=True,
+                            drop_duplicates=True):
         """Takes the dataframe and the path to a directory
          and generates batches of augmented/normalized data.
 
@@ -1088,6 +1090,9 @@ class ImageDataGenerator(object):
                 If PIL version 1.1.3 or newer is installed, `"lanczos"` is also
                 supported. If PIL version 3.4.0 or newer is installed, `"box"` and
                 `"hamming"` are also supported. By default, `"nearest"` is used.
+            sort: Boolean, whether to sort dataframe by filename (before shuffle).
+            drop_duplicates: Boolean, whether to drop duplicate rows
+                based on filename.
 
         # Returns
             A DataFrameIterator yielding tuples of `(x, y)`
@@ -1106,7 +1111,9 @@ class ImageDataGenerator(object):
                                  save_prefix=save_prefix,
                                  save_format=save_format,
                                  subset=subset,
-                                 interpolation=interpolation)
+                                 interpolation=interpolation,
+                                 sort=sort,
+                                 drop_duplicates=drop_duplicates)
 
     def standardize(self, x):
         """Applies the normalization configuration to a batch of inputs.
@@ -2022,6 +2029,8 @@ class DataFrameIterator(Iterator):
             If PIL version 1.1.3 or newer is installed, "lanczos" is also
             supported. If PIL version 3.4.0 or newer is installed, "box" and
             "hamming" are also supported. By default, "nearest" is used.
+        sort: Boolean, whether to sort dataframe by filename (before shuffle).
+        drop_duplicates: Boolean, whether to drop duplicate rows based on filename.
     """
 
     def __init__(self, dataframe, directory, image_data_generator,
@@ -2034,7 +2043,9 @@ class DataFrameIterator(Iterator):
                  follow_links=False,
                  subset=None,
                  interpolation='nearest',
-                 dtype='float32'):
+                 dtype='float32',
+                 sort=True,
+                 drop_duplicates=True):
         super(DataFrameIterator, self).common_init(image_data_generator,
                                                    target_size,
                                                    color_mode,
@@ -2053,7 +2064,9 @@ class DataFrameIterator(Iterator):
         if type(has_ext) != bool:
             raise ValueError("has_ext must be either True if filenames in"
                              " x_col has extensions,else False.")
-        self.df = dataframe.drop_duplicates(x_col)
+        self.df = dataframe.copy()
+        if drop_duplicates:
+            self.df.drop_duplicates(x_col, inplace=True)
         self.df[x_col] = self.df[x_col].astype(str)
         self.directory = directory
         self.classes = classes
@@ -2100,15 +2113,18 @@ class DataFrameIterator(Iterator):
             if not ext_exist:
                 raise ValueError('has_ext is set to True but'
                                  ' extension not found in x_col')
-            self.df = self.df[self.df[x_col].isin(filenames)].sort_values(by=x_col)
+            self.df = self.df[self.df[x_col].isin(filenames)]
+            if sort:
+                self.df.sort_values(by=x_col, inplace=True)
             self.filenames = list(self.df[x_col])
         else:
             without_ext_with = {f[:-1 * (len(f.split(".")[-1]) + 1)]: f
                                 for f in filenames}
             filenames_without_ext = [f[:-1 * (len(f.split(".")[-1]) + 1)]
                                      for f in filenames]
-            self.df = (self.df[self.df[x_col].isin(filenames_without_ext)]
-                       .sort_values(by=x_col))
+            self.df = self.df[self.df[x_col].isin(filenames_without_ext)]
+            if sort:
+                self.df.sort_values(by=x_col, inplace=True)
             self.filenames = [without_ext_with[f] for f in list(self.df[x_col])]
         if class_mode not in ["other", "input", None]:
             classes = self.df[y_col].values

--- a/tests/image_test.py
+++ b/tests/image_test.py
@@ -775,7 +775,7 @@ class TestImage(object):
 
         # prepare input_filenames
         n_files = len(filenames)
-        idx_rand, idx_rand2 = random.choices(range(1, n_files), k=2)
+        idx_rand, idx_rand2 = np.random.randint(1, n_files, size=2)
         input_filenames = filenames[::-1]  # reversed
         input_filenames2 = filenames[:idx_rand] + filenames[:idx_rand2]
 

--- a/tests/image_test.py
+++ b/tests/image_test.py
@@ -761,6 +761,48 @@ class TestImage(object):
         assert df_iterator.n == n_files - 2
         assert df2_iterator.n == n_files - 2
 
+    def test_dataframe_iterator_with_sort_and_drop_duplicates(self, tmpdir):
+
+        # save the images in the tmpdir
+        count = 0
+        filenames = []
+        for test_images in self.all_test_images:
+            for im in test_images:
+                filename = "image-{:0>5}.png".format(count)
+                filenames.append(filename)
+                im.save(str(tmpdir / filename))
+                count += 1
+
+        # prepare input_filenames
+        n_files = len(filenames)
+        idx_rand, idx_rand2 = random.choices(range(1, n_files), k=2)
+        input_filenames = filenames[::-1]  # reversed
+        input_filenames2 = filenames[:idx_rand] + filenames[:idx_rand2]
+
+        # create dataframes
+        df = pd.DataFrame({"filename": input_filenames})
+        df2 = pd.DataFrame({"filename": input_filenames2})
+
+        # create iterators
+        generator = image.ImageDataGenerator()
+        df_sort_iterator = generator.flow_from_dataframe(
+            df, str(tmpdir), class_mode=None, sort=True, shuffle=False)
+        df_no_sort_iterator = generator.flow_from_dataframe(
+            df, str(tmpdir), class_mode=None, sort=False, shuffle=False)
+        df_drop_iterator = generator.flow_from_dataframe(
+            df2, str(tmpdir), class_mode=None, drop_duplicates=True)
+        df_no_drop_iterator = generator.flow_from_dataframe(
+            df2, str(tmpdir), class_mode=None, drop_duplicates=False)
+
+        # Test sort
+        assert df_sort_iterator.filenames == df_no_sort_iterator.filenames[::-1]
+        assert df_sort_iterator.filenames[0] == filenames[0]
+        assert df_no_sort_iterator.filenames[0] == filenames[-1]
+
+        # Test drop_duplicates
+        assert df_drop_iterator.n == len(set(input_filenames2))
+        assert df_no_drop_iterator.n == len(input_filenames2)
+
     def test_img_utils(self):
         height, width = 10, 8
 


### PR DESCRIPTION
### Summary

Add "sort" and "drop_duplicates" option to DataFrameIterator to be able to generate data according to just as the input dataframe order.

### Related Issues

#72

### PR Overview

- [x] This PR requires new unit tests [y/n] (make sure tests are included)
- [x] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
