### PR TITLE
Fix for formatting of flow_from_dataframe in the docs.

### DIFF
--- a/keras_preprocessing/image.py
+++ b/keras_preprocessing/image.py
@@ -1046,7 +1046,8 @@ class ImageDataGenerator(object):
         """Takes the dataframe and the path to a directory
          and generates batches of augmented/normalized data.
 
-        # A simple tutorial can be found at: http://bit.ly/keras_flow_from_dataframe
+        **A simple tutorial can be found **[here](
+                                    http://bit.ly/keras_flow_from_dataframe).
 
         # Arguments
             dataframe: Pandas dataframe containing the filenames of the


### PR DESCRIPTION
Fixes keras-team/keras#11623

### Summary
- Changed the flow_from_dataframe docstring to correct the formatting. 
- Changed the plain text link to hyperlink.
### Related Issues

### PR Overview

- [n] This PR requires new unit tests [y/n] (make sure tests are included)
- [y] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
