### PR TITLE
Sort classes in DataFrameIterator

### DIFF
--- a/keras_preprocessing/image.py
+++ b/keras_preprocessing/image.py
@@ -2107,7 +2107,7 @@ class DataFrameIterator(Iterator):
         if not classes:
             classes = []
             if class_mode not in ["other", "input", None]:
-                classes = list(self.df[y_col].unique())
+                classes = list(np.sort(self.df[y_col].unique()))
         else:
             if class_mode in ["other", "input", None]:
                 raise ValueError('classes cannot be set if class_mode'


### PR DESCRIPTION
### Summary
Currently, when the `classes` argument in `flow_from_dataframe` is not set, it would automatically find the classes by using pandas Series `unique` method. However, this method would return the unique values in order of appearance. Therefore, in scenarios where we have separate dataframes for training/validation/test it might result in inconsistent class indices mapping. Here is minimal example:

```python
import pandas as pd
import numpy as np
from keras.preprocessing.image import ImageDataGenerator

df_tr = pd.DataFrame({'files': ['tr_img1.jpg', 'tr_img2.jpg'],
                      'labels': ['cat', 'dog']})
df_val = pd.DataFrame({'files': ['val_img1.jpg', 'val_img2.jpg'],
                       'labels': ['dog', 'cat']})

img_gen = ImageDataGenerator()
tr_gen = img_gen.flow_from_dataframe(df_tr, 'dir', x_col='files', y_col='labels', class_mode='binary')
val_gen = img_gen.flow_from_dataframe(df_val, 'dir', x_col='files', y_col='labels', class_mode='binary')

print(tr_gen.class_indices)    # {'cat': 0, 'dog': 1}
print(val_gen.class_indices)   # {'cat': 1, 'dog': 0}
```
Notice that `cat` and `dog` are assigned different indices in train and validation generators.

To resolve this issue, this PR sort the classes to make sure the indices mapping would be the same. 
### Related Issues

### PR Overview

- [n] This PR requires new unit tests [y/n] (make sure tests are included)
- [n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
