### PR TITLE
Fix flaky test in test_image_data_generator

### DIFF
--- a/tests/image_test.py
+++ b/tests/image_test.py
@@ -97,7 +97,8 @@ class TestImage(object):
             for x, y in generator.flow(images, np.arange(images.shape[0]),
                                        shuffle=True,
                                        save_to_dir=str(tmpdir),
-                                       batch_size=3):
+                                       batch_size=3,
+                                       seed=42):
                 assert x.shape == images[:3].shape
                 # Check that the sequence is shuffled.
                 assert list(y) != [0, 1, 2]


### PR DESCRIPTION
### Summary
This PR fixes the flaky test in `test_image_data_generator`. We just set the `seed` to make sure the shuffled data would not be in the same order.

### Related Issues
#98 
### PR Overview

- [n] This PR requires new unit tests [y/n] (make sure tests are included)
- [n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
