### PR TITLE
Remove unnecessary import and type checks

### DIFF
--- a/keras_preprocessing/image.py
+++ b/keras_preprocessing/image.py
@@ -2076,15 +2076,6 @@ class DataFrameIterator(Iterator):
                                                    save_format,
                                                    subset,
                                                    interpolation)
-        try:
-            import pandas as pd
-        except ImportError:
-            raise ImportError('Install pandas to use flow_from_dataframe.')
-        if type(x_col) != str:
-            raise ValueError("x_col must be a string.")
-        if type(has_ext) != bool:
-            raise ValueError("has_ext must be either True if filenames in"
-                             " x_col has extensions,else False.")
         self.df = dataframe.copy()
         if drop_duplicates:
             self.df.drop_duplicates(x_col, inplace=True)


### PR DESCRIPTION
### Summary
There is a check if pandas can be imported but the pandas module is not use at all in the code. I guess the committer of the code thought that you need the pandas package in the namespace in order to performs methods of a pandas object, which is not the case, that's not how namespaces work. If the user is giving a pandas Dataframe as input argument there is no need to have pandas in the scope to call methods belonging to that Dataframe. Also, the only way the user can send a pandas dataframe is because pandas is installed as a top package or depency. This PR removes that unnecessary check which is also not good practice and not Pythonic. The same thing goes with the type checking of `has_ext` and `x_col`, if you decide to go that route then you need to type check every argument in the function which is  not the way to go. The documentation should state the types which it does already. 

P.D. if you want to do this in a package you should use the typing module and a decorator to enforce it, but then you loose backward compatibility and also Keras code format does not conform with this type checking.

### PR Overview

- [n ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [ y] This PR is backwards compatible [y/n]
- [ n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
