### PR TITLE
Dictionary iterator

### DIFF
--- a/keras_preprocessing/image/dataframe_iterator.py
+++ b/keras_preprocessing/image/dataframe_iterator.py
@@ -21,17 +21,12 @@ class DataFrameIterator(Iterator):
 
     # Arguments
         dataframe: Pandas dataframe containing the filepaths relative to
-            `directory` of the images in a column and classes in another
-            column/s that can be fed as raw target data.
-        directory: Path to the directory to read images from.
-            Each subdirectory in this directory will be
-            considered to contain images from one class,
-            or alternatively you could specify class subdirectories
-            via the `classes` argument.
-            if used with dataframe,this will be the directory to under which
-            all the images are present.
-            You could also set it to None if data in x_col column are
-            absolute paths.
+            `directory` or absolute paths if `directory` is None of the images
+            in a column and classes in another column/s that can be fed as raw
+            target data.
+        directory: string, path to the directory to read images from. Directory to
+            under which all the images are present. If None, data in x_col column
+            should be absolute paths.
         image_data_generator: Instance of `ImageDataGenerator` to use for
             random transformations and normalization. If None, no transformations
             and normalizations are made.

--- a/keras_preprocessing/image/dictionary_iterator.py
+++ b/keras_preprocessing/image/dictionary_iterator.py
@@ -56,7 +56,9 @@ class DictionaryIterator(Iterator):
             By default, "nearest" is used.
         dtype: Dtype to use for generated arrays.
     """
-    allowed_class_modes = {'categorical', 'binary', 'sparse', 'input', None}
+    allowed_class_modes = {
+        'categorical', 'binary', 'multi-output', 'sparse', 'input', None
+    }
 
     def __init__(self, dictionary, image_data_generator,
                  directory=None,
@@ -116,7 +118,7 @@ class DictionaryIterator(Iterator):
             classes = set()
             for v in dictionary.values():
                 if isinstance(v, (list, tuple)):
-                    classes.union(v)
+                    classes.update(v)
                 else:
                     classes.add(v)
         return dictionary, classes
@@ -144,7 +146,7 @@ class DictionaryIterator(Iterator):
                     os.path.isfile(filepath)):
                 filepaths.append(filepath)
                 if isinstance(label, (list, tuple)):
-                    labels.extend(self.class_indices[lbl] for lbl in label)
+                    labels.append([self.class_indices[lbl] for lbl in label])
                 else:
                     labels.append(self.class_indices[label])
         return filepaths, labels
@@ -187,6 +189,9 @@ class DictionaryIterator(Iterator):
                                dtype=self.dtype)
             for i, n_observation in enumerate(index_array):
                 batch_y[i, self.labels[n_observation]] = 1.
+        elif self.class_mode == 'multi-output':
+            batch_y = list(np.array(self.labels)[index_array].T)
+            print(batch_y)
         else:
             return batch_x
         return batch_x, batch_y

--- a/keras_preprocessing/image/dictionary_iterator.py
+++ b/keras_preprocessing/image/dictionary_iterator.py
@@ -1,0 +1,192 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import os
+import numpy as np
+
+from .iterator import Iterator
+from .utils import (array_to_img,
+                    get_extension,
+                    img_to_array,
+                    load_img)
+
+
+class DictionaryIterator(Iterator):
+    """Iterator capable of reading images from a directory on disk through a dictionary.
+
+    # Arguments
+        dictionary: Filenames or filepaths as keys and class labels as values.
+        image_data_generator: Instance of `ImageDataGenerator` to use for
+            random transformations and normalization.
+        directory: Filenames in directory will be looked in this directory
+            if provided. Only PNG, JPG, JPEG, BMP, PPM, TIF or TIFF extensions
+            will be considered.
+        target_size: tuple of integers, dimensions to resize input images to.
+        color_mode: One of `"rgb"`, `"rgba"`, `"grayscale"`.
+            Color mode to read images.
+        classes: Use only these classes (e.g. `["dogs", "cats"]`).
+        class_mode: Mode for yielding the targets:
+            `"binary"`: binary targets (if there are only two classes),
+            `"categorical"`: categorical targets,
+            `"sparse"`: integer targets,
+            `"input"`: targets are images identical to input images (mainly
+                used to work with autoencoders),
+            `None`: no targets get yielded (only input images are yielded).
+        batch_size: Integer, size of a batch.
+        shuffle: Boolean, whether to shuffle the data between epochs.
+        seed: Random seed for data shuffling.
+        data_format: String, one of `channels_first`, `channels_last`.
+        save_to_dir: Optional directory where to save the pictures
+            being yielded, in a viewable format. This is useful
+            for visualizing the random transformations being
+            applied, for debugging purposes.
+        save_prefix: String prefix to use for saving sample images
+            (if `save_to_dir` is set).
+        save_format: Format to use for saving sample images
+            (if `save_to_dir` is set).
+        subset: Subset of data (`"training"` or `"validation"`) if
+            validation_split is set in ImageDataGenerator.
+        interpolation: Interpolation method used to resample the image if
+            the target size is different from that of the loaded image.
+            Supported methods are "nearest", "bilinear", and "bicubic".
+            If PIL version 1.1.3 or newer is installed, "lanczos" is also supported.
+            If PIL version 3.4.0 or newer is installed, "box" and "hamming"
+                are also supported.
+            By default, "nearest" is used.
+        dtype: Dtype to use for generated arrays.
+    """
+    allowed_class_modes = {'categorical', 'binary', 'sparse', 'input', None}
+
+    def __init__(self, dictionary, image_data_generator,
+                 directory=None,
+                 target_size=(256, 256),
+                 color_mode='rgb',
+                 classes=None,
+                 class_mode='categorical',
+                 batch_size=32,
+                 shuffle=True,
+                 seed=None,
+                 data_format='channels_last',
+                 save_to_dir=None,
+                 save_prefix='',
+                 save_format='png',
+                 subset=None,
+                 interpolation='nearest',
+                 dtype='float32'):
+        super(DictionaryIterator, self).common_init(image_data_generator,
+                                                    target_size,
+                                                    color_mode,
+                                                    data_format,
+                                                    save_to_dir,
+                                                    save_prefix,
+                                                    save_format,
+                                                    subset,
+                                                    interpolation)
+        dictionary, classes = self._filter_classes(dictionary, classes)
+        if class_mode not in self.allowed_class_modes:
+            raise ValueError('Invalid class_mode: {}; expected one of: {}'
+                             .format(class_mode, self.allowed_class_modes))
+        self.class_mode = class_mode
+        self.dtype = dtype
+        # build an index of all the unique classes.
+        self.class_indices = dict(zip(classes, range(len(classes))))
+        # check which image files are valid
+        self.filepaths, self.labels = self._list_filepaths_and_labels(dictionary,
+                                                                      directory)
+        if self.split:  # create training or validation split
+            num_files = len(self.filepaths)
+            start = int(self.split[0] * num_files)
+            stop = int(self.split[1] * num_files)
+            self.filepaths = self.filepaths[start: stop]
+            self.labels = self.labels[start: stop]
+
+        print('Found %d images belonging to %d classes.' %
+              (len(self.filepaths), len(self.class_indices)))
+        super(DictionaryIterator, self).__init__(len(self.filepaths),
+                                                 batch_size,
+                                                 shuffle,
+                                                 seed)
+
+    def _filter_classes(self, dictionary, classes):
+        if classes:
+            classes = set(classes)
+            dictionary = {k: v for k, v in dictionary.items() if v in classes}
+        else:
+            classes = set()
+            for v in dictionary.values():
+                if isinstance(v, (list, tuple)):
+                    classes.union(v)
+                else:
+                    classes.add(v)
+        return dictionary, classes
+
+    def _list_filepaths_and_labels(self, dictionary, directory):
+        """List valid filepaths and their respective class labels
+
+        If directory is None the filenames in the directory keys will
+        be taken as absolute paths to the image files. If directory is not
+        None it will be taken as the root directory of the filenames in the
+        dictionary keys.
+
+        # Arguments
+            dictionary: Filenames as keys and class labels as values.
+            directory: Path to the directory to read images from.
+
+        # Returns
+            filepaths, labels: filepaths with an allowed extension and the
+                corresponding class labels
+        """
+        filepaths, labels, root = [], [], directory or ''
+        for filename, label in dictionary.items():
+            filepath = os.path.join(root, filename)
+            if (get_extension(filename) in self.white_list_formats and
+                    os.path.isfile(filepath)):
+                filepaths.append(filepath)
+                if isinstance(label, (list, tuple)):
+                    labels.extend(self.class_indices[lbl] for lbl in label)
+                else:
+                    labels.append(self.class_indices[label])
+        return filepaths, labels
+
+    def _get_batches_of_transformed_samples(self, index_array):
+        batch_x = np.zeros((len(index_array),) + self.image_shape, dtype=self.dtype)
+        # build batch of image data
+        for i, j in enumerate(index_array):
+            img = load_img(self.filepaths[j],
+                           color_mode=self.color_mode,
+                           target_size=self.target_size,
+                           interpolation=self.interpolation)
+            x = img_to_array(img, data_format=self.data_format)
+            # Pillow images should be closed after `load_img`, but not PIL images.
+            if hasattr(img, 'close'):
+                img.close()
+            params = self.image_data_generator.get_random_transform(x.shape)
+            x = self.image_data_generator.apply_transform(x, params)
+            x = self.image_data_generator.standardize(x)
+            batch_x[i] = x
+        # optionally save augmented images to disk for debugging purposes
+        if self.save_to_dir:
+            for i, j in enumerate(index_array):
+                img = array_to_img(batch_x[i], self.data_format, scale=True)
+                fname = '{prefix}_{index}_{hash}.{format}'.format(
+                    prefix=self.save_prefix,
+                    index=j,
+                    hash=np.random.randint(1e7),
+                    format=self.save_format)
+                img.save(os.path.join(self.save_to_dir, fname))
+        # build batch of labels
+        if self.class_mode == 'input':
+            batch_y = batch_x.copy()
+        elif self.class_mode in {'binary', 'sparse'}:
+            batch_y = np.empty(len(batch_x), dtype=self.dtype)
+            for i, n_observation in enumerate(index_array):
+                batch_y[i] = self.labels[n_observation]
+        elif self.class_mode == 'categorical':
+            batch_y = np.zeros((len(batch_x), len(self.class_indices)),
+                               dtype=self.dtype)
+            for i, n_observation in enumerate(index_array):
+                batch_y[i, self.labels[n_observation]] = 1.
+        else:
+            return batch_x
+        return batch_x, batch_y

--- a/keras_preprocessing/image/dictionary_iterator.py
+++ b/keras_preprocessing/image/dictionary_iterator.py
@@ -121,7 +121,7 @@ class DictionaryIterator(Iterator):
                     classes.update(v)
                 else:
                     classes.add(v)
-        return dictionary, classes
+        return dictionary, sorted(classes)
 
     def _list_filepaths_and_labels(self, dictionary, directory):
         """List valid filepaths and their respective class labels

--- a/keras_preprocessing/image/dictionary_iterator.py
+++ b/keras_preprocessing/image/dictionary_iterator.py
@@ -191,7 +191,6 @@ class DictionaryIterator(Iterator):
                 batch_y[i, self.labels[n_observation]] = 1.
         elif self.class_mode == 'multi-output':
             batch_y = list(np.array(self.labels)[index_array].T)
-            print(batch_y)
         else:
             return batch_x
         return batch_x, batch_y

--- a/keras_preprocessing/image/image_data_generator.py
+++ b/keras_preprocessing/image/image_data_generator.py
@@ -19,6 +19,7 @@ except ImportError:
     scipy = None
 
 from .dataframe_iterator import DataFrameIterator
+from .dictionary_iterator import DictionaryIterator
 from .directory_iterator import DirectoryIterator
 from .numpy_array_iterator import NumpyArrayIterator
 from .affine_transformations import (apply_affine_transform,
@@ -654,6 +655,94 @@ class ImageDataGenerator(object):
             interpolation=interpolation,
             sort=sort,
             drop_duplicates=drop_duplicates
+        )
+
+    def flow_from_dictionary(self,
+                             dictionary,
+                             directory=None,
+                             target_size=(256, 256),
+                             color_mode='rgb',
+                             classes=None,
+                             class_mode='categorical',
+                             batch_size=32,
+                             shuffle=True,
+                             seed=None,
+                             save_to_dir=None,
+                             save_prefix='',
+                             save_format='png',
+                             subset=None,
+                             interpolation='nearest'):
+        """Takes a dictionary with image filenames and class labels and generates
+        batches of augmented data.
+
+        # Arguments
+            dictionary: Filenames or filepaths as keys and class labels as values.
+            directory: string, filenames in `directory` will be looked in this
+            directory if provided. Only PNG, JPG, JPEG, BMP, PPM, TIF or TIFF
+            extensions will be considered.
+            target_size: Tuple of integers `(height, width)`. Default: `(256, 256)`.
+                The dimensions to which all images found will be resized.
+            color_mode: One of "grayscale", "rgb", "rgba". Default: "rgb".
+                Whether the images will be converted to have 1, 3, or 4 channels.
+            classes: Optional list of classes to use  (e.g. `['dogs', 'cats']`).
+                If not provided, the list of classes will be automatically
+                created from the dictionary values. The dictionary containing
+                the mapping from class names to class indices can be obtained
+                via the attribute `class_indices`.
+            class_mode: One of "categorical", "binary", "sparse", "input", or None.
+                Default: "categorical".
+                Determines the type of target that is returned:
+                - "categorical": 2D one-hot encoded labels,
+                - "binary": 1D binary labels,
+                  "sparse": 1D integer labels,
+                - "input": identical to input images (mainly used to work
+                    with autoencoders).
+                - None: no labels are returned (the generator will only
+                    yield batches of image data, which is useful to use with
+                    `model.predict_generator()`,
+                    `model.evaluate_generator()`, etc.).
+            batch_size: Size of the batches of data (default: 32).
+            shuffle: Whether to shuffle the data (default: True)
+            seed: Optional random seed for shuffling and transformations.
+            save_to_dir: None or str (default: None).
+                This allows you to optionally specify a directory to which to
+                save the augmented pictures being generated. This is useful
+                for visualizing the random transformations being applied, for
+                debugging purposes.
+            save_format: One of "png", "jpeg" (if `save_to_dir` is set).
+                Default: "png".
+            subset: Subset of data (`"training"` or `"validation"`) if
+                validation_split` is set in `ImageDataGenerator`.
+            interpolation: Interpolation method used to resample the image
+                if the target size is different from that of the loaded image.
+                Supported methods are `"nearest"`, `"bilinear"` and `"bicubic"`.
+                If PIL version 1.1.3 or newer, `"lanczos"` is also supported.
+                If PIL version 3.4.0 or newer,`"box"` and `"hamming"` are
+                    also supported.
+                By default, `"nearest"` is used.
+        # Returns
+            A `DirectoryIterator` yielding tuples of `(x, y)` where `x` is a
+            numpy array containing a batch of images with shape
+            `(batch_size, height, width, channels)` and `y` is a numpy array
+            of corresponding targets.
+        """
+        return DictionaryIterator(
+            dictionary,
+            self,
+            directory=directory,
+            target_size=target_size,
+            color_mode=color_mode,
+            classes=classes,
+            class_mode=class_mode,
+            data_format=self.data_format,
+            batch_size=batch_size,
+            shuffle=shuffle,
+            seed=seed,
+            save_to_dir=save_to_dir,
+            save_prefix=save_prefix,
+            save_format=save_format,
+            subset=subset,
+            interpolation=interpolation
         )
 
     def standardize(self, x):

--- a/tests/image_test.py
+++ b/tests/image_test.py
@@ -1296,6 +1296,26 @@ class TestImage(object):
         output_img[0][0][0] += 1
         assert(input_img[0][0][0] != output_img[0][0][0])
 
+    def test_dictionary_iterator_class_mode_multi_output(self, tmpdir):
+        root, filenames = self.write_images_for_dictionary_iterator(str(tmpdir))
+        dictionary = dict(zip(
+            filenames,
+            [[random.randint(10, 11), random.randint(10, 11)] for _ in filenames]
+        ))
+        generator = image.ImageDataGenerator()
+        dict_iterator = generator.flow_from_dictionary(dictionary, root,
+                                                       class_mode='multi-output')
+        batch_x, batch_y = next(dict_iterator)
+        assert isinstance(batch_x, np.ndarray)
+        assert len(batch_x.shape) == 4
+        assert isinstance(batch_y, list)
+        assert len(batch_y) == 2
+        for output in batch_y:
+            assert isinstance(output, np.ndarray)
+            assert len(output) == len(batch_x)
+            for label in output:
+                assert label in {0, 1}
+
     @pytest.mark.parametrize('validation_split,num_training', [
         (0.25, 18),
         (0.50, 12),

--- a/tests/image_test.py
+++ b/tests/image_test.py
@@ -1333,27 +1333,24 @@ class TestImage(object):
         for labels in batch_y:
             assert all(l in {0, 1} for l in labels)
 
-        print(filenames)
         dictionary = dict(zip(
             filenames,
-            [['b', 'a']] + ['b'] + [['a']] +
+            [['b', 'a']] + ['b'] + [['c']] +
             [random.choice(label_options) for _ in filenames[:-2]]
         ))
         generator = image.ImageDataGenerator()
         dict_iterator = generator.flow_from_dictionary(dictionary, root,
                                                        shuffle=False)
-        print(dict_iterator.filepaths)
-        print(dict_iterator.labels)
         batch_x, batch_y = next(dict_iterator)
         assert isinstance(batch_x, np.ndarray)
         assert len(batch_x.shape) == 4
         assert isinstance(batch_y, np.ndarray)
-        assert batch_y.shape == (len(batch_x), 2)
+        assert batch_y.shape == (len(batch_x), 3)
         for labels in batch_y:
             assert all(l in {0, 1} for l in labels)
-        assert (batch_y[0] == np.array([1, 1])).all()
-        assert (batch_y[1] == np.array([0, 1])).all()
-        assert (batch_y[2] == np.array([1, 0])).all()
+        assert (batch_y[0] == np.array([1, 1, 0])).all()
+        assert (batch_y[1] == np.array([0, 1, 0])).all()
+        assert (batch_y[2] == np.array([0, 0, 1])).all()
 
     @pytest.mark.parametrize('validation_split,num_training', [
         (0.25, 18),

--- a/tests/image_test.py
+++ b/tests/image_test.py
@@ -8,6 +8,8 @@ import keras
 import pandas as pd
 import random
 
+from collections import OrderedDict
+
 # TODO: remove the 3 lines below once the Keras release
 # is configured to use keras_preprocessing
 import keras_preprocessing
@@ -1333,7 +1335,9 @@ class TestImage(object):
         for labels in batch_y:
             assert all(l in {0, 1} for l in labels)
 
-        dictionary = dict(zip(
+        # use OrderedDict to mantain order in python 2.7 and allow for checks
+        # on first 3 batches
+        dictionary = OrderedDict(zip(
             filenames,
             [['b', 'a']] + ['b'] + [['c']] +
             [random.choice(label_options) for _ in filenames[:-2]]


### PR DESCRIPTION
### Summary
This PR adds a `DictionaryIterator` class and `flow_from_dictionary` method. This class is quite flexible as it allows to send full-paths without relative to a directory parameters. Which will allow to fetch images from different root directories. The next step is to leverage this flexible API to include multi-output batches that match the functional Keras API and the multi-label one. Some of the internal logic has also been simplified in comparison with `DataframeIterator` (which in my opinion should be deprecated for several reasons, one of the main ones a dependency on the Pandas API which has substantially changed in the past).

I imagine having the well known `DirectoryIterator` for the already known simple use cases and `DictionaryIterator` for the more advance ones because of flexibility.

### PR Overview

- [y ] This PR requires new unit tests [y/n] (make sure tests are included)
- [y] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
