### PR TITLE
Mode class modes as class attribute and refactor error message

### DIFF
--- a/keras_preprocessing/image/dataframe_iterator.py
+++ b/keras_preprocessing/image/dataframe_iterator.py
@@ -75,6 +75,9 @@ class DataFrameIterator(Iterator):
         sort: Boolean, whether to sort dataframe by filename (before shuffle).
         drop_duplicates: Boolean, whether to drop duplicate rows based on filename.
     """
+    allowed_class_modes = {
+        'categorical', 'binary', 'sparse', 'input', 'other', None
+    }
 
     def __init__(self, dataframe, directory, image_data_generator,
                  x_col="filenames", y_col="class", has_ext=True,
@@ -105,12 +108,9 @@ class DataFrameIterator(Iterator):
         self.df[x_col] = self.df[x_col].astype(str)
         self.directory = directory
         self.classes = classes
-        if class_mode not in {'categorical', 'binary', 'sparse',
-                              'input', 'other', None}:
-            raise ValueError('Invalid class_mode:', class_mode,
-                             '; expected one of "categorical", '
-                             '"binary", "sparse", "input"'
-                             '"other" or None.')
+        if class_mode not in self.allowed_class_modes:
+            raise ValueError('Invalid class_mode: {}; expected one of: {}'
+                             .format(class_mode, self.allowed_class_modes))
         self.class_mode = class_mode
         self.dtype = dtype
         # First, count the number of samples and classes.

--- a/keras_preprocessing/image/directory_iterator.py
+++ b/keras_preprocessing/image/directory_iterator.py
@@ -63,6 +63,7 @@ class DirectoryIterator(Iterator):
             "hamming" are also supported. By default, "nearest" is used.
         dtype: Dtype to use for generated arrays.
     """
+    allowed_class_modes = {'categorical', 'binary', 'sparse', 'input', None}
 
     def __init__(self, directory, image_data_generator,
                  target_size=(256, 256), color_mode='rgb',
@@ -85,12 +86,9 @@ class DirectoryIterator(Iterator):
                                                    interpolation)
         self.directory = directory
         self.classes = classes
-        if class_mode not in {'categorical', 'binary', 'sparse',
-                              'input', None}:
-            raise ValueError('Invalid class_mode:', class_mode,
-                             '; expected one of "categorical", '
-                             '"binary", "sparse", "input"'
-                             ' or None.')
+        if class_mode not in self.allowed_class_modes:
+            raise ValueError('Invalid class_mode: {}; expected one of: {}'
+                             .format(class_mode, self.allowed_class_modes))
         self.class_mode = class_mode
         self.dtype = dtype
         # First, count the number of samples and classes.


### PR DESCRIPTION
### Summary
Class modes are currently hardcoded in the code logic, and present in two places. In the logic check and in the error message. This PR solves both things, it's not a good practice to hardcode in the logic and if not possible then is best to make it an attribute, then this PR also refactor the error message to use this attribute such that if it's updated the error message updates as well.

### PR Overview

- [ n] This PR requires new unit tests [y/n] (make sure tests are included)
- [ n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [ y] This PR is backwards compatible [y/n]
- [ n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
