### PR TITLE
Remove sort

### DIFF
--- a/keras_preprocessing/image/dataframe_iterator.py
+++ b/keras_preprocessing/image/dataframe_iterator.py
@@ -72,7 +72,6 @@ class DataFrameIterator(Iterator):
             If PIL version 1.1.3 or newer is installed, "lanczos" is also
             supported. If PIL version 3.4.0 or newer is installed, "box" and
             "hamming" are also supported. By default, "nearest" is used.
-        sort: Boolean, whether to sort dataframe by filename (before shuffle).
         drop_duplicates: Boolean, whether to drop duplicate rows based on filename.
     """
     allowed_class_modes = {
@@ -99,7 +98,6 @@ class DataFrameIterator(Iterator):
                  subset=None,
                  interpolation='nearest',
                  dtype='float32',
-                 sort=True,
                  drop_duplicates=True):
         super(DataFrameIterator, self).common_init(image_data_generator,
                                                    target_size,
@@ -133,9 +131,6 @@ class DataFrameIterator(Iterator):
         self.num_classes = len(classes)
         self.class_indices = dict(zip(classes, range(len(classes))))
         self.df = self._filter_valid_filepaths(self.df)
-        if sort:
-            self.df.sort_values(by=x_col, inplace=True)
-
         if self.split:
             num_files = len(self.df)
             start = int(self.split[0] * num_files)

--- a/keras_preprocessing/image/image_data_generator.py
+++ b/keras_preprocessing/image/image_data_generator.py
@@ -556,7 +556,6 @@ class ImageDataGenerator(object):
                             save_format='png',
                             subset=None,
                             interpolation='nearest',
-                            sort=True,
                             drop_duplicates=True,
                             **kwargs):
         """Takes the dataframe and the path to a directory
@@ -619,7 +618,6 @@ class ImageDataGenerator(object):
                 If PIL version 1.1.3 or newer is installed, `"lanczos"` is also
                 supported. If PIL version 3.4.0 or newer is installed, `"box"` and
                 `"hamming"` are also supported. By default, `"nearest"` is used.
-            sort: Boolean, whether to sort dataframe by filename (before shuffle).
             drop_duplicates: Boolean, whether to drop duplicate rows
                 based on filename.
 
@@ -652,7 +650,6 @@ class ImageDataGenerator(object):
             save_format=save_format,
             subset=subset,
             interpolation=interpolation,
-            sort=sort,
             drop_duplicates=drop_duplicates
         )
 

--- a/keras_preprocessing/image/image_data_generator.py
+++ b/keras_preprocessing/image/image_data_generator.py
@@ -631,6 +631,10 @@ class ImageDataGenerator(object):
             warnings.warn('has_ext is deprecated, filenames in the dataframe have '
                           'to match the exact filenames in disk.',
                           DeprecationWarning)
+        if 'sort' in kwargs:
+            warnings.warn('sort is deprecated, batches will be created in the'
+                          'same order than the filenames provided if shuffle'
+                          'is set to False.')
         return DataFrameIterator(
             dataframe,
             directory,

--- a/tests/image_test.py
+++ b/tests/image_test.py
@@ -822,7 +822,7 @@ class TestImage(object):
             assert np.array_equal(a1, a4)
             assert np.array_equal(a1, a5)
 
-    def test_dataframe_iterator_with_sort_and_drop_duplicates(self, tmpdir):
+    def test_dataframe_iterator_with_drop_duplicates(self, tmpdir):
 
         # save the images in the tmpdir
         count = 0
@@ -846,19 +846,10 @@ class TestImage(object):
 
         # create iterators
         generator = image.ImageDataGenerator()
-        df_sort_iterator = generator.flow_from_dataframe(
-            df, str(tmpdir), class_mode=None, sort=True, shuffle=False)
-        df_no_sort_iterator = generator.flow_from_dataframe(
-            df, str(tmpdir), class_mode=None, sort=False, shuffle=False)
         df_drop_iterator = generator.flow_from_dataframe(
             df2, str(tmpdir), class_mode=None, drop_duplicates=True)
         df_no_drop_iterator = generator.flow_from_dataframe(
             df2, str(tmpdir), class_mode=None, drop_duplicates=False)
-
-        # Test sort
-        assert df_sort_iterator.filenames == df_no_sort_iterator.filenames[::-1]
-        assert df_sort_iterator.filenames[0] == filenames[0]
-        assert df_no_sort_iterator.filenames[0] == filenames[-1]
 
         # Test drop_duplicates
         assert df_drop_iterator.n == len(set(input_filenames2))

--- a/tests/image_test.py
+++ b/tests/image_test.py
@@ -536,6 +536,11 @@ class TestImage(object):
         assert len(df_iterator.classes) == count
         assert set(df_iterator.filenames) == set(filenames)
         assert batch_y.shape[1] == 2
+        # test shuffle=False
+        _, batch_y = next(generator.flow_from_dataframe(df, str(tmpdir),
+                                                        shuffle=False,
+                                                        class_mode="sparse"))
+        assert (batch_y == df['class'].tolist()[:len(batch_y)]).all()
         # Test invalid use cases
         with pytest.raises(ValueError):
             generator.flow_from_dataframe(df, str(tmpdir), color_mode='cmyk')


### PR DESCRIPTION
### Summary
Currently the `DataframeIterator` has an argument `sort`. This argument doesn't add to the internal logic that `DataframeIterator` should worry about. Even if used, `sort` is used before `shuffle` for yielding the batches so there is no use for it other than having a pretty arrangement of the `filenames` attribute. But if that's what the user wants then the user can call `sort_values` on the dataframe column before sending it as an argument. This PR removes the `sort` logic which it actually only calls `sort_values` form Pandas, this improves readability in the code, easier to maintain as the logic was in several places and also in my opinion sorting has nothing to do with the logic that  `DataframeIterator` should be handling.

### PR Overview

- [n ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y ] This PR is backwards compatible [y/n]
- [ n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
