### PR TITLE
Remove has ext

### DIFF
--- a/keras_preprocessing/image/dataframe_iterator.py
+++ b/keras_preprocessing/image/dataframe_iterator.py
@@ -143,14 +143,13 @@ class DataFrameIterator(Iterator):
         self.df = self._filter_valid_filepaths(self.df)
         if sort:
             self.df.sort_values(by=x_col, inplace=True)
-        self.filenames = self.df[x_col].tolist()
 
         if self.split:
-            num_files = len(self.filenames)
+            num_files = len(self.df)
             start = int(self.split[0] * num_files)
             stop = int(self.split[1] * num_files)
             self.df = self.df.iloc[start: stop, :]
-            self.filenames = self.filenames[start: stop]
+        self.filenames = self.df[x_col].tolist()
 
         if class_mode not in ["other", "input", None]:
             classes = self.df[y_col].values

--- a/keras_preprocessing/image/dataframe_iterator.py
+++ b/keras_preprocessing/image/dataframe_iterator.py
@@ -20,9 +20,9 @@ class DataFrameIterator(Iterator):
         through a dataframe.
 
     # Arguments
-        dataframe: Pandas dataframe containing the filenames
-            (or paths relative to `directory`) of the images in a column and
-            classes in another column/s that can be fed as raw target data.
+        dataframe: Pandas dataframe containing the filepaths relative to
+            `directory` of the images in a column and classes in another
+            column/s that can be fed as raw target data.
         directory: Path to the directory to read images from.
             Each subdirectory in this directory will be
             considered to contain images from one class,
@@ -38,7 +38,6 @@ class DataFrameIterator(Iterator):
         x_col: Column in dataframe that contains all the filenames (or absolute
             paths, if directory is set to None).
         y_col: Column/s in dataframe that has the target data.
-        has_ext: bool, Whether the filenames in x_col has extensions or not.
         target_size: tuple of integers, dimensions to resize input images to.
         color_mode: One of `"rgb"`, `"rgba"`, `"grayscale"`.
             Color mode to read images.
@@ -152,31 +151,11 @@ class DataFrameIterator(Iterator):
                 follow_links=follow_links,
                 df=True)
         else:
-            if not has_ext:
-                raise ValueError('has_ext cannot be set to False'
-                                 ' if directory is None.')
             filenames = self._list_valid_filepaths(self.white_list_formats)
-
-        if has_ext:
-            ext_exist = False
-            if get_extension(self.df[x_col].values[0]) in self.white_list_formats:
-                ext_exist = True
-            if not ext_exist:
-                raise ValueError('has_ext is set to True but'
-                                 ' extension not found in x_col')
-            self.df = self.df[self.df[x_col].isin(filenames)]
-            if sort:
-                self.df.sort_values(by=x_col, inplace=True)
-            self.filenames = list(self.df[x_col])
-        else:
-            without_ext_with = {f[:-1 * (len(f.split(".")[-1]) + 1)]: f
-                                for f in filenames}
-            filenames_without_ext = [f[:-1 * (len(f.split(".")[-1]) + 1)]
-                                     for f in filenames]
-            self.df = self.df[self.df[x_col].isin(filenames_without_ext)]
-            if sort:
-                self.df.sort_values(by=x_col, inplace=True)
-            self.filenames = [without_ext_with[f] for f in list(self.df[x_col])]
+        self.df = self.df[self.df[x_col].isin(filenames)]
+        if sort:
+            self.df.sort_values(by=x_col, inplace=True)
+        self.filenames = list(self.df[x_col])
 
         if self.split:
             num_files = len(self.filenames)

--- a/keras_preprocessing/image/dataframe_iterator.py
+++ b/keras_preprocessing/image/dataframe_iterator.py
@@ -115,7 +115,6 @@ class DataFrameIterator(Iterator):
         if drop_duplicates:
             self.df.drop_duplicates(x_col, inplace=True)
         self.x_col = x_col
-        self.df[x_col] = self.df[x_col].astype(str)
         self.directory = directory
         self.classes = classes
         if class_mode not in self.allowed_class_modes:

--- a/keras_preprocessing/image/dataframe_iterator.py
+++ b/keras_preprocessing/image/dataframe_iterator.py
@@ -85,7 +85,6 @@ class DataFrameIterator(Iterator):
                  image_data_generator=None,
                  x_col="filename",
                  y_col="class",
-                 has_ext=True,
                  target_size=(256, 256),
                  color_mode='rgb',
                  classes=None,

--- a/keras_preprocessing/image/dataframe_iterator.py
+++ b/keras_preprocessing/image/dataframe_iterator.py
@@ -123,8 +123,6 @@ class DataFrameIterator(Iterator):
                              .format(class_mode, self.allowed_class_modes))
         self.class_mode = class_mode
         self.dtype = dtype
-        # First, count the number of samples and classes.
-        self.samples = 0
 
         if not classes:
             classes = []

--- a/keras_preprocessing/image/dataframe_iterator.py
+++ b/keras_preprocessing/image/dataframe_iterator.py
@@ -134,10 +134,6 @@ class DataFrameIterator(Iterator):
                                  ' is either "other" or "input" or None.')
         self.num_classes = len(classes)
         self.class_indices = dict(zip(classes, range(len(classes))))
-
-        # Second, build an index of the images.
-        self.classes = np.zeros((self.samples,), dtype='int32')
-
         self.df = self._filter_valid_filepaths(self.df)
         if sort:
             self.df.sort_values(by=x_col, inplace=True)

--- a/keras_preprocessing/image/dataframe_iterator.py
+++ b/keras_preprocessing/image/dataframe_iterator.py
@@ -97,7 +97,6 @@ class DataFrameIterator(Iterator):
                  save_to_dir=None,
                  save_prefix='',
                  save_format='png',
-                 follow_links=False,
                  subset=None,
                  interpolation='nearest',
                  dtype='float32',

--- a/keras_preprocessing/image/image_data_generator.py
+++ b/keras_preprocessing/image/image_data_generator.py
@@ -208,8 +208,7 @@ class ImageDataGenerator(object):
     ```
 
     Example of using ```.flow_from_dataframe(dataframe, directory,
-                                            x_col, y_col,
-                                            has_ext)```:
+                                            x_col, y_col)```:
 
     ```python
 
@@ -229,7 +228,6 @@ class ImageDataGenerator(object):
             directory='data/train',
             x_col="filename",
             y_col="class",
-            has_ext=True,
             target_size=(150, 150),
             batch_size=32,
             class_mode='binary')
@@ -239,7 +237,6 @@ class ImageDataGenerator(object):
             directory='data/validation',
             x_col="filename",
             y_col="class",
-            has_ext=True,
             target_size=(150, 150),
             batch_size=32,
             class_mode='binary')
@@ -579,8 +576,6 @@ class ImageDataGenerator(object):
                 the filenames of the target images.
             y_col: string or list of strings,columns in
                 the dataframe that will be the target data.
-            has_ext: bool, True if filenames in dataframe[x_col]
-                has filename extensions,else False.
             target_size: tuple of integers `(height, width)`, default: `(256, 256)`.
                 The dimensions to which all images found will be resized.
             color_mode: one of "grayscale", "rgb". Default: "rgb".
@@ -634,7 +629,6 @@ class ImageDataGenerator(object):
             of images with shape `(batch_size, *target_size, channels)`
             and `y` is a numpy array of corresponding labels.
         """
-
         return DataFrameIterator(
             dataframe,
             directory,

--- a/keras_preprocessing/image/image_data_generator.py
+++ b/keras_preprocessing/image/image_data_generator.py
@@ -544,7 +544,6 @@ class ImageDataGenerator(object):
                             directory,
                             x_col="filename",
                             y_col="class",
-                            has_ext=True,
                             target_size=(256, 256),
                             color_mode='rgb',
                             classes=None,
@@ -558,7 +557,8 @@ class ImageDataGenerator(object):
                             subset=None,
                             interpolation='nearest',
                             sort=True,
-                            drop_duplicates=True):
+                            drop_duplicates=True,
+                            **kwargs):
         """Takes the dataframe and the path to a directory
          and generates batches of augmented/normalized data.
 
@@ -629,13 +629,16 @@ class ImageDataGenerator(object):
             of images with shape `(batch_size, *target_size, channels)`
             and `y` is a numpy array of corresponding labels.
         """
+        if 'has_ext' in kwargs:
+            warnings.warn('has_ext is deprecated, filenames in the dataframe have '
+                          'to match the exact filenames in disk.',
+                          DeprecationWarning)
         return DataFrameIterator(
             dataframe,
             directory,
             self,
             x_col=x_col,
             y_col=y_col,
-            has_ext=has_ext,
             target_size=target_size,
             color_mode=color_mode,
             classes=classes,

--- a/keras_preprocessing/image/utils.py
+++ b/keras_preprocessing/image/utils.py
@@ -177,14 +177,10 @@ def _list_valid_filenames_in_directory(directory, white_list_formats, split,
         follow_links: boolean.
 
     # Returns
-        classes: a list of class indices(returns only if `df=False`)
-        filenames: if `df=False`,returns the path of valid files in `directory`,
-            relative from `directory`'s parent (e.g., if `directory` is
-            "dataset", the filenames will be
-            `["dataset/class1/file1.jpg", "dataset/class1/file2.jpg", ...]`).
-            if `df=True`, returns the path of valid files in `directory`,
-            relative from `directory` (e.g., if `directory` is
-            "dataset", the filenames will be
+         classes: a list of class indices
+         filenames: the path of valid files in `directory`, relative from
+             `directory`'s parent (e.g., if `directory` is "dataset/class1",
+            the filenames will be
             `["class1/file1.jpg", "class1/file2.jpg", ...]`).
     """
     dirname = os.path.basename(directory)

--- a/keras_preprocessing/image/utils.py
+++ b/keras_preprocessing/image/utils.py
@@ -160,7 +160,7 @@ def _iter_valid_files(directory, white_list_formats, follow_links):
 
 
 def _list_valid_filenames_in_directory(directory, white_list_formats, split,
-                                       class_indices, follow_links, df=False):
+                                       class_indices, follow_links):
     """Lists paths of files in `subdir` with extensions in `white_list_formats`.
 
     # Arguments
@@ -175,7 +175,6 @@ def _list_valid_filenames_in_directory(directory, white_list_formats, split,
             of images in each directory.
         class_indices: dictionary mapping a class name to its index.
         follow_links: boolean.
-        df: boolean
 
     # Returns
         classes: a list of class indices(returns only if `df=False`)
@@ -199,13 +198,6 @@ def _list_valid_filenames_in_directory(directory, white_list_formats, split,
     else:
         valid_files = _iter_valid_files(
             directory, white_list_formats, follow_links)
-    if df:
-        filenames = []
-        for root, fname in valid_files:
-            absolute_path = os.path.join(root, fname)
-            relative_path = os.path.relpath(absolute_path, directory)
-            filenames.append(relative_path)
-        return filenames
     classes = []
     filenames = []
     for root, fname in valid_files:

--- a/tests/image_test.py
+++ b/tests/image_test.py
@@ -504,9 +504,8 @@ class TestImage(object):
         assert isinstance(batch[1], np.ndarray)
         generator = image.ImageDataGenerator()
         df_iterator = generator.flow_from_dataframe(
-            df, str(tmpdir), has_ext=True)
+            df, str(tmpdir))
         df_sparse_iterator = generator.flow_from_dataframe(df, str(tmpdir),
-                                                           has_ext=True,
                                                            class_mode="sparse")
         if np.isnan(df_sparse_iterator.classes).any():
             raise ValueError('Invalid values.')
@@ -522,8 +521,7 @@ class TestImage(object):
                                       "col2": [random.randrange(0, 1)
                                                for _ in filenames]})
         df_multiple_y_iterator = generator.flow_from_dataframe(
-            df_regression, str(tmpdir), y_col=["col1", "col2"],
-            has_ext=True, class_mode="other")
+            df_regression, str(tmpdir), y_col=["col1", "col2"], class_mode="other")
         df_regression = pd.DataFrame({"filename": filenames,
                                       "col1": [random.randrange(0, 1)
                                                for _ in filenames],
@@ -534,11 +532,10 @@ class TestImage(object):
         with pytest.raises(TypeError):
             df_multiple_y_iterator = generator.flow_from_dataframe(
                 df_regression, str(tmpdir), y_col=["col1", "col2"],
-                has_ext=True, class_mode="other")
+                class_mode="other")
         with pytest.raises(TypeError):
             df_single_y_iterator = generator.flow_from_dataframe(
-                df_regression, str(tmpdir), y_col="col1",
-                has_ext=True, class_mode="other")
+                df_regression, str(tmpdir), y_col="col1", class_mode="other")
         # check number of classes and images
         assert len(df_iterator.class_indices) == num_classes
         assert len(df_iterator.classes) == count
@@ -549,14 +546,11 @@ class TestImage(object):
         assert batch_y.shape[1] == 2
         # Test invalid use cases
         with pytest.raises(ValueError):
-            generator.flow_from_dataframe(df, str(tmpdir), color_mode='cmyk',
-                                          has_ext=True)
+            generator.flow_from_dataframe(df, str(tmpdir), color_mode='cmyk')
         with pytest.raises(ValueError):
-            generator.flow_from_dataframe(df, str(tmpdir), class_mode='output',
-                                          has_ext=True)
+            generator.flow_from_dataframe(df, str(tmpdir), class_mode='output')
         with pytest.raises(ValueError):
-            generator.flow_from_dataframe(df_without_ext, str(tmpdir),
-                                          has_ext=True)
+            generator.flow_from_dataframe(df_without_ext, str(tmpdir))
 
         def preprocessing_function(x):
             """This will fail if not provided by a Numpy array.
@@ -575,8 +569,7 @@ class TestImage(object):
                                                 target_size=(26, 26),
                                                 color_mode='rgb',
                                                 batch_size=3,
-                                                class_mode='categorical',
-                                                has_ext=True)
+                                                class_mode='categorical')
         assert len(dir_seq) == np.ceil(count / 3)
         x1, y1 = dir_seq[1]
         assert x1.shape == (3, 26, 26, 3)
@@ -606,7 +599,6 @@ class TestImage(object):
         df_autoencoder_iterator = generator.flow_from_dataframe(df, str(tmpdir),
                                                                 x_col="filename",
                                                                 y_col=None,
-                                                                has_ext=True,
                                                                 class_mode="input")
 
         batch = next(df_autoencoder_iterator)
@@ -622,7 +614,6 @@ class TestImage(object):
         df_autoencoder_iterator = generator.flow_from_dataframe(df, str(tmpdir),
                                                                 x_col="filename",
                                                                 y_col="class",
-                                                                has_ext=True,
                                                                 class_mode="input")
 
         batch = next(df_autoencoder_iterator)
@@ -667,20 +658,19 @@ class TestImage(object):
         generator = image.ImageDataGenerator(validation_split=validation_split)
         df_sparse_iterator = generator.flow_from_dataframe(df,
                                                            str(tmpdir),
-                                                           has_ext=True,
                                                            class_mode="sparse")
         if np.isnan(next(df_sparse_iterator)[:][1]).any():
             raise ValueError('Invalid values.')
 
         with pytest.raises(ValueError):
             generator.flow_from_dataframe(
-                df, tmpdir, has_ext=True, subset='foo')
+                df, tmpdir, subset='foo')
 
-        train_iterator = generator.flow_from_dataframe(df, str(tmpdir), has_ext=True,
+        train_iterator = generator.flow_from_dataframe(df, str(tmpdir),
                                                        subset='training')
         assert train_iterator.samples == num_training
 
-        valid_iterator = generator.flow_from_dataframe(df, str(tmpdir), has_ext=True,
+        valid_iterator = generator.flow_from_dataframe(df, str(tmpdir),
                                                        subset='validation')
         assert valid_iterator.samples == count - num_training
 
@@ -732,11 +722,11 @@ class TestImage(object):
         seed = 1
         generator = image.ImageDataGenerator()
         df_iterator = generator.flow_from_dataframe(
-            df, str(tmpdir), has_ext=True, seed=seed)
+            df, str(tmpdir), seed=seed)
         df2_iterator = generator.flow_from_dataframe(
-            df2, str(tmpdir), has_ext=True, seed=seed)
+            df2, str(tmpdir), seed=seed)
         df3_iterator = generator.flow_from_dataframe(
-            df3, str(tmpdir), has_ext=True, seed=seed)
+            df3, str(tmpdir), seed=seed)
 
         # Test all iterators return same pairs of arrays
         for _ in range(len(filenames)):
@@ -773,9 +763,9 @@ class TestImage(object):
         # create iterators
         generator = image.ImageDataGenerator()
         df_iterator = generator.flow_from_dataframe(
-            df, str(tmpdir), has_ext=True, class_mode=None)
+            df, str(tmpdir), class_mode=None)
         df2_iterator = generator.flow_from_dataframe(
-            df2, str(tmpdir), has_ext=True, class_mode='binary')
+            df2, str(tmpdir), class_mode='binary')
 
         # Test the number of items in iterators
         assert df_iterator.n == n_files - 2
@@ -809,25 +799,25 @@ class TestImage(object):
         # create iterators
         generator = image.ImageDataGenerator()
         df_iterator = generator.flow_from_dataframe(
-            df, None, has_ext=True, class_mode=None,
+            df, None, class_mode=None,
             shuffle=False, batch_size=1)
         df2_iterator = generator.flow_from_dataframe(
-            df2, None, has_ext=True, class_mode='binary',
+            df2, None, class_mode='binary',
             shuffle=False, batch_size=1)
         df3_iterator = generator.flow_from_dataframe(
-            df3, None, has_ext=True, class_mode=None,
+            df3, None, class_mode=None,
             shuffle=False, batch_size=1)
         df4_iterator = generator.flow_from_dataframe(
-            df4, None, has_ext=True, class_mode=None,
+            df4, None, class_mode=None,
             shuffle=False, batch_size=1)
 
         validation_split = 0.2
         generator_split = image.ImageDataGenerator(validation_split=validation_split)
         df_train_iterator = generator_split.flow_from_dataframe(
-            df, None, has_ext=True, class_mode=None,
+            df, None, class_mode=None,
             shuffle=False, subset='training', batch_size=1)
         df_val_iterator = generator_split.flow_from_dataframe(
-            df, None, has_ext=True, class_mode=None,
+            df, None, class_mode=None,
             shuffle=False, subset='validation', batch_size=1)
 
         # Test invalid use cases
@@ -946,7 +936,7 @@ class TestImage(object):
         # create iterator
         generator = image.ImageDataGenerator()
         df_iterator = generator.flow_from_dataframe(
-            df, str(tmpdir), has_ext=True, class_mode='binary')
+            df, str(tmpdir), class_mode='binary')
 
         # Test the number of items in iterator
         assert df_iterator.n == len(filenames)

--- a/tests/image_test.py
+++ b/tests/image_test.py
@@ -541,6 +541,10 @@ class TestImage(object):
             generator.flow_from_dataframe(df, str(tmpdir), color_mode='cmyk')
         with pytest.raises(ValueError):
             generator.flow_from_dataframe(df, str(tmpdir), class_mode='output')
+        with pytest.warns(DeprecationWarning):
+            generator.flow_from_dataframe(df, str(tmpdir), has_ext=True)
+        with pytest.warns(DeprecationWarning):
+            generator.flow_from_dataframe(df, str(tmpdir), has_ext=False)
 
         def preprocessing_function(x):
             """This will fail if not provided by a Numpy array.
@@ -572,7 +576,7 @@ class TestImage(object):
 
     def test_valid_args(self):
         with pytest.raises(ValueError):
-            dt = image.ImageDataGenerator(brightness_range=0.1)
+            image.ImageDataGenerator(brightness_range=0.1)
 
     def test_dataframe_iterator_class_mode_input(self, tmpdir):
         # save the images in the paths


### PR DESCRIPTION
### Summary
At the moment there is in my view unnecessary logic in the `DataframeIterator` class to handle user provided filenames without extension. Also this unnecessary logic leads to bad code practices and bugs. Some of them are:
- unnecessary double check for valid list in directory, as it only works if directory is set (137-144 and 149) it  can be done in one pass.
- logic for has_ext only checks the first element of x_col. If first element has extension
but all the other do not then the logic fails (line 153)
- why has_ext cannot be set to False if directory is none? the user should give then the fullpaths in the dataframe (lines 145-148). This logic fails because you have basically two places defining if there is an extensions (the has_ext and the filenames in the dataframe themselves).
- then such a complicated logic to deal with file extensions if has_ext is false (lines 160-164). 

The committer mentions the use case of a Kaggle competition in (https://medium.com/@vijayabhaskar96/tutorial-on-keras-flow-from-dataframe-1fd4493d237c), but in the use cases I've worked in real-life I've never received the data like this (images in disk, some collection of filenames without extension). Normally we collect the filenames and then (as he points out in the blog post) I build my own `DataGenerator` which extends from `Sequence` where I feed in this list of filenames pointing to some file on disk, this is the most common use case by far and I've seen it several times. I think this library aims to solve real use cases.

In short I think the user should be responsible for setting filenames in the `x_col` which exist in the `directory`. This will also allow the user to have flexibility if some have extension and other don't for example.

This PR simplifies the whole process of getting valid filenames, basically doing the computation in a single pass of the df by filtering it. It also cleans up a bit of unnecessary attributes being set which later are overwritten.

### PR Overview

- [ n] This PR requires new unit tests [y/n] (make sure tests are included)
- [ n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [ y] This PR is backwards compatible [y/n]
- [ n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
