### PR TITLE
Default directory

### DIFF
--- a/keras_preprocessing/image/dataframe_iterator.py
+++ b/keras_preprocessing/image/dataframe_iterator.py
@@ -21,17 +21,12 @@ class DataFrameIterator(Iterator):
 
     # Arguments
         dataframe: Pandas dataframe containing the filepaths relative to
-            `directory` of the images in a column and classes in another
-            column/s that can be fed as raw target data.
-        directory: Path to the directory to read images from.
-            Each subdirectory in this directory will be
-            considered to contain images from one class,
-            or alternatively you could specify class subdirectories
-            via the `classes` argument.
-            if used with dataframe,this will be the directory to under which
-            all the images are present.
-            You could also set it to None if data in x_col column are
-            absolute paths.
+            `directory` or absolute paths if `directory` is None of the images
+            in a column and classes in another column/s that can be fed as raw
+            target data.
+        directory: Path to the directory to read images from. Directory to
+            under which all the images are present. If None, data in x_col column
+            should be absolute paths.
         image_data_generator: Instance of `ImageDataGenerator` to use for
             random transformations and normalization. If None, no transformations
             and normalizations are made.
@@ -79,9 +74,14 @@ class DataFrameIterator(Iterator):
         'categorical', 'binary', 'sparse', 'input', 'other', None
     }
 
+<<<<<<< HEAD
     def __init__(self,
                  dataframe,
                  directory,
+=======
+    def __init__(self, dataframe,
+                 directory=None,
+>>>>>>> Set default directory parameter as None
                  image_data_generator=None,
                  x_col="filename",
                  y_col="class",

--- a/keras_preprocessing/image/dataframe_iterator.py
+++ b/keras_preprocessing/image/dataframe_iterator.py
@@ -24,7 +24,7 @@ class DataFrameIterator(Iterator):
             `directory` or absolute paths if `directory` is None of the images
             in a column and classes in another column/s that can be fed as raw
             target data.
-        directory: Path to the directory to read images from. Directory to
+        directory: string, path to the directory to read images from. Directory to
             under which all the images are present. If None, data in x_col column
             should be absolute paths.
         image_data_generator: Instance of `ImageDataGenerator` to use for
@@ -74,14 +74,9 @@ class DataFrameIterator(Iterator):
         'categorical', 'binary', 'sparse', 'input', 'other', None
     }
 
-<<<<<<< HEAD
     def __init__(self,
                  dataframe,
-                 directory,
-=======
-    def __init__(self, dataframe,
                  directory=None,
->>>>>>> Set default directory parameter as None
                  image_data_generator=None,
                  x_col="filename",
                  y_col="class",

--- a/keras_preprocessing/image/directory_iterator.py
+++ b/keras_preprocessing/image/directory_iterator.py
@@ -21,7 +21,7 @@ class DirectoryIterator(Iterator):
     """Iterator capable of reading images from a directory on disk.
 
     # Arguments
-        directory: Path to the directory to read images from.
+        directory: string, path to the directory to read images from.
             Each subdirectory in this directory will be
             considered to contain images from one class,
             or alternatively you could specify class subdirectories

--- a/keras_preprocessing/image/image_data_generator.py
+++ b/keras_preprocessing/image/image_data_generator.py
@@ -449,7 +449,7 @@ class ImageDataGenerator(object):
         """Takes the path to a directory & generates batches of augmented data.
 
         # Arguments
-            directory: Path to the target directory.
+            directory: string, path to the target directory.
                 It should contain one subdirectory per class.
                 Any PNG, JPG, BMP, PPM or TIF images
                 inside each of the subdirectories directory tree
@@ -566,13 +566,9 @@ class ImageDataGenerator(object):
                                     http://bit.ly/keras_flow_from_dataframe).
 
         # Arguments
-            dataframe: Pandas dataframe containing the filepaths relative to
-                `directory` or absolute paths if `directory` is None of the images
-                in a column and classes in another column/s that can be fed as raw
-                target data.
-            directory: Path to the directory to read images from. Directory to
-                under which all the images are present. If None, data in
-                x_col column should be absolute paths.
+            directory: string, path to the directory to read images from.
+                Directory to under which all the images are present.
+                If None, data in x_col column should be absolute paths.
             x_col: string, column in the dataframe that contains
                 the filenames of the target images.
             y_col: string or list of strings,columns in

--- a/keras_preprocessing/image/image_data_generator.py
+++ b/keras_preprocessing/image/image_data_generator.py
@@ -541,7 +541,7 @@ class ImageDataGenerator(object):
 
     def flow_from_dataframe(self,
                             dataframe,
-                            directory,
+                            directory=None,
                             x_col="filename",
                             y_col="class",
                             target_size=(256, 256),
@@ -566,12 +566,13 @@ class ImageDataGenerator(object):
                                     http://bit.ly/keras_flow_from_dataframe).
 
         # Arguments
-            dataframe: Pandas dataframe containing the filenames
-                (or paths relative to `directory`) of the images in a column and
-                classes in another column/s that can be fed as raw target data.
-            directory: string, path to the target directory that contains all
-                the images mapped in the dataframe.
-                None if x_col column contains absolute paths.
+            dataframe: Pandas dataframe containing the filepaths relative to
+                `directory` or absolute paths if `directory` is None of the images
+                in a column and classes in another column/s that can be fed as raw
+                target data.
+            directory: Path to the directory to read images from. Directory to
+                under which all the images are present. If None, data in
+                x_col column should be absolute paths.
             x_col: string, column in the dataframe that contains
                 the filenames of the target images.
             y_col: string or list of strings,columns in

--- a/tests/image_test.py
+++ b/tests/image_test.py
@@ -543,9 +543,6 @@ class TestImage(object):
         assert len(df_iterator_dir.class_indices) == num_classes
         assert len(df_iterator_dir.classes) == count
         assert set(df_iterator_dir.filenames) == set(filenames)
-        assert len(df_without_ext_iterator.class_indices) == num_classes
-        assert len(df_without_ext_iterator.classes) == count
-        assert set(df_without_ext_iterator.filenames) == set(filenames)
         assert batch_y.shape[1] == 2
         # Test invalid use cases
         with pytest.raises(ValueError):


### PR DESCRIPTION
### Summary
The documentation in `flow_from_dataframe` and `DataframeIterator` states that if `directory` is None then the filenames are taken as absolute paths. I agree with this behavior, and I think this should be the default behavior if no directory parameter is given. This PR sets the default directory parameter as None and adds the corresponding tests. With this PR is enough to have the absolute paths in a Dataframe and just send that dataframe as parameter to `flow_from_dataframe`

Closses #67 #56 #116 

### PR Overview

- [y] This PR requires new unit tests [y/n] (make sure tests are included)
- [n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
