### PR TITLE
[WIP] Update base Iterator class

### DIFF
--- a/keras_preprocessing/image/dataframe_iterator.py
+++ b/keras_preprocessing/image/dataframe_iterator.py
@@ -147,7 +147,7 @@ class DataFrameIterator(Iterator):
             classes = self.df[y_col].values
             self.classes = np.array([self.class_indices[cls] for cls in classes])
         elif class_mode == "other":
-            self.data = self.df[y_col].values
+            self._data = self.df[y_col].values
             if type(y_col) == str:
                 y_col = [y_col]
             if "object" in list(self.df[y_col].dtypes):
@@ -164,60 +164,6 @@ class DataFrameIterator(Iterator):
                                                 shuffle,
                                                 seed)
 
-    def _get_batches_of_transformed_samples(self, index_array):
-        batch_x = np.zeros(
-            (len(index_array),) + self.image_shape,
-            dtype=self.dtype)
-        # build batch of image data
-        for i, j in enumerate(index_array):
-            fname = self.filenames[j]
-            if self.directory is not None:
-                img_path = os.path.join(self.directory, fname)
-            else:
-                img_path = fname
-            img = load_img(img_path,
-                           color_mode=self.color_mode,
-                           target_size=self.target_size,
-                           interpolation=self.interpolation)
-            x = img_to_array(img, data_format=self.data_format)
-            # Pillow images should be closed after `load_img`,
-            # but not PIL images.
-            if hasattr(img, 'close'):
-                img.close()
-            if self.image_data_generator:
-                params = self.image_data_generator.get_random_transform(x.shape)
-                x = self.image_data_generator.apply_transform(x, params)
-                x = self.image_data_generator.standardize(x)
-            batch_x[i] = x
-        # optionally save augmented images to disk for debugging purposes
-        if self.save_to_dir:
-            for i, j in enumerate(index_array):
-                img = array_to_img(batch_x[i], self.data_format, scale=True)
-                fname = '{prefix}_{index}_{hash}.{format}'.format(
-                    prefix=self.save_prefix,
-                    index=j,
-                    hash=np.random.randint(1e7),
-                    format=self.save_format)
-                img.save(os.path.join(self.save_to_dir, fname))
-        # build batch of labels
-        if self.class_mode == 'input':
-            batch_y = batch_x.copy()
-        elif self.class_mode == 'sparse':
-            batch_y = self.classes[index_array]
-        elif self.class_mode == 'binary':
-            batch_y = self.classes[index_array].astype(self.dtype)
-        elif self.class_mode == 'categorical':
-            batch_y = np.zeros(
-                (len(batch_x), self.num_classes),
-                dtype=self.dtype)
-            for i, label in enumerate(self.classes[index_array]):
-                batch_y[i, label] = 1.
-        elif self.class_mode == 'other':
-            batch_y = self.data[index_array]
-        else:
-            return batch_x
-        return batch_x, batch_y
-
     def _filter_valid_filepaths(self, df):
         """Keep only dataframe rows with valid filenames
 
@@ -233,3 +179,16 @@ class DataFrameIterator(Iterator):
         format_check = filepaths.map(get_extension).isin(self.white_list_formats)
         existence_check = filepaths.map(os.path.isfile)
         return df[format_check & existence_check]
+
+    @property
+    def filepaths(self):
+        root = self.directory or ''
+        return [os.path.join(root, fname) for fname in self.filenames]
+
+    @property
+    def labels(self):
+        return self.classes
+
+    @property
+    def data(self):
+        return self._data

--- a/keras_preprocessing/image/directory_iterator.py
+++ b/keras_preprocessing/image/directory_iterator.py
@@ -142,49 +142,10 @@ class DirectoryIterator(Iterator):
                                                 shuffle,
                                                 seed)
 
-    def _get_batches_of_transformed_samples(self, index_array):
-        batch_x = np.zeros(
-            (len(index_array),) + self.image_shape,
-            dtype=self.dtype)
-        # build batch of image data
-        for i, j in enumerate(index_array):
-            fname = self.filenames[j]
-            img = load_img(os.path.join(self.directory, fname),
-                           color_mode=self.color_mode,
-                           target_size=self.target_size,
-                           interpolation=self.interpolation)
-            x = img_to_array(img, data_format=self.data_format)
-            # Pillow images should be closed after `load_img`,
-            # but not PIL images.
-            if hasattr(img, 'close'):
-                img.close()
-            params = self.image_data_generator.get_random_transform(x.shape)
-            x = self.image_data_generator.apply_transform(x, params)
-            x = self.image_data_generator.standardize(x)
-            batch_x[i] = x
-        # optionally save augmented images to disk for debugging purposes
-        if self.save_to_dir:
-            for i, j in enumerate(index_array):
-                img = array_to_img(batch_x[i], self.data_format, scale=True)
-                fname = '{prefix}_{index}_{hash}.{format}'.format(
-                    prefix=self.save_prefix,
-                    index=j,
-                    hash=np.random.randint(1e7),
-                    format=self.save_format)
-                img.save(os.path.join(self.save_to_dir, fname))
-        # build batch of labels
-        if self.class_mode == 'input':
-            batch_y = batch_x.copy()
-        elif self.class_mode == 'sparse':
-            batch_y = self.classes[index_array]
-        elif self.class_mode == 'binary':
-            batch_y = self.classes[index_array].astype(self.dtype)
-        elif self.class_mode == 'categorical':
-            batch_y = np.zeros(
-                (len(batch_x), self.num_classes),
-                dtype=self.dtype)
-            for i, label in enumerate(self.classes[index_array]):
-                batch_y[i, label] = 1.
-        else:
-            return batch_x
-        return batch_x, batch_y
+    @property
+    def filepaths(self):
+        return [os.path.join(self.directory, fname) for fname in self.filenames]
+
+    @property
+    def labels(self):
+        return self.classes

--- a/keras_preprocessing/image/iterator.py
+++ b/keras_preprocessing/image/iterator.py
@@ -174,6 +174,7 @@ class Iterator(IteratorType):
             (len(index_array),) + self.image_shape,
             dtype=self.dtype)
         # build batch of image data
+        # self.filepaths is dynamic, is better to call it once outside the loop
         filepaths = self.filepaths
         for i, j in enumerate(index_array):
             img = load_img(filepaths[j],
@@ -221,6 +222,7 @@ class Iterator(IteratorType):
 
     @property
     def filepaths(self):
+        """List of absolute paths to image files"""
         raise NotImplementedError(
             '`filepaths` property method has not been implemented in {}.'
             .format(type(self).__name__)
@@ -228,6 +230,7 @@ class Iterator(IteratorType):
 
     @property
     def labels(self):
+        """Class labels of every observation"""
         raise NotImplementedError(
             '`labels` property method has not been implemented in {}.'
             .format(type(self).__name__)

--- a/keras_preprocessing/image/iterator.py
+++ b/keras_preprocessing/image/iterator.py
@@ -149,17 +149,6 @@ class Iterator(IteratorType):
     def __next__(self, *args, **kwargs):
         return self.next(*args, **kwargs)
 
-    def _get_batches_of_transformed_samples(self, index_array):
-        """Gets a batch of transformed samples.
-
-        # Arguments
-            index_array: Array of sample indices to include in batch.
-
-        # Returns
-            A batch of transformed samples.
-        """
-        raise NotImplementedError
-
     def next(self):
         """For python 2.x.
 
@@ -173,6 +162,14 @@ class Iterator(IteratorType):
         return self._get_batches_of_transformed_samples(index_array)
 
     def _get_batches_of_transformed_samples(self, index_array):
+        """Gets a batch of transformed samples.
+
+        # Arguments
+            index_array: Array of sample indices to include in batch.
+
+        # Returns
+            A batch of transformed samples.
+        """
         batch_x = np.zeros(
             (len(index_array),) + self.image_shape,
             dtype=self.dtype)

--- a/keras_preprocessing/image/iterator.py
+++ b/keras_preprocessing/image/iterator.py
@@ -174,7 +174,7 @@ class Iterator(IteratorType):
             (len(index_array),) + self.image_shape,
             dtype=self.dtype)
         # build batch of image data
-        fielpaths = self.filepaths
+        filepaths = self.filepaths
         for i, j in enumerate(index_array):
             img = load_img(filepaths[j],
                            color_mode=self.color_mode,
@@ -221,12 +221,21 @@ class Iterator(IteratorType):
 
     @property
     def filepaths(self):
-        raise NotImplementedError('filepaths property has not been implemented.')
+        raise NotImplementedError(
+            '`filepaths` property method has not been implemented in {}.'
+            .format(type(self).__name__)
+        )
 
     @property
     def labels(self):
-        raise NotImplementedError('labels property has not been implemented.')
+        raise NotImplementedError(
+            '`labels` property method has not been implemented in {}.'
+            .format(type(self).__name__)
+        )
 
     @property
     def data(self):
-        raise NotImplementedError('data property has not been implemented.')
+        raise NotImplementedError(
+            '`data` property method has not been implemented in {}.'
+            .format(type(self).__name__)
+        )


### PR DESCRIPTION
### Summary
Currently both `DataFrameIterator` and `DirectoryIterator` contain the `_get_batches_of_transformed_samples` method, but both methods do the same thing, and the logic is slightly different. This PR merges both method versions and adds the method to the base class. This PR avoid this code duplication and in my opinion also simplifies the logic a little bit by stating that is enough to collect `filepaths` and `labels` from any child class of `Iterator` to make things work. Therefore both `filepaths` and `labels` are declared as properties and an `NotImplementedError` is raised if not overwritten by the child class.

### PR Overview

- [n] This PR requires new unit tests [y/n] (make sure tests are included)
- [n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
