### PR TITLE
Refactor iterator

### DIFF
--- a/keras_preprocessing/image/dataframe_iterator.py
+++ b/keras_preprocessing/image/dataframe_iterator.py
@@ -7,14 +7,14 @@ from __future__ import print_function
 import os
 import numpy as np
 
-from .iterator import Iterator
+from .iterator import BatchFromFilesMixin, Iterator
 from .utils import (array_to_img,
                     get_extension,
                     img_to_array,
                     load_img)
 
 
-class DataFrameIterator(Iterator):
+class DataFrameIterator(Iterator, BatchFromFilesMixin):
     """Iterator capable of reading images from a directory on disk
         through a dataframe.
 
@@ -93,15 +93,15 @@ class DataFrameIterator(Iterator):
                  interpolation='nearest',
                  dtype='float32',
                  drop_duplicates=True):
-        super(DataFrameIterator, self).common_init(image_data_generator,
-                                                   target_size,
-                                                   color_mode,
-                                                   data_format,
-                                                   save_to_dir,
-                                                   save_prefix,
-                                                   save_format,
-                                                   subset,
-                                                   interpolation)
+        super(DataFrameIterator, self).set_processing_attrs(image_data_generator,
+                                                            target_size,
+                                                            color_mode,
+                                                            data_format,
+                                                            save_to_dir,
+                                                            save_prefix,
+                                                            save_format,
+                                                            subset,
+                                                            interpolation)
         self.df = dataframe.copy()
         if drop_duplicates:
             self.df.drop_duplicates(x_col, inplace=True)

--- a/keras_preprocessing/image/dataframe_iterator.py
+++ b/keras_preprocessing/image/dataframe_iterator.py
@@ -136,7 +136,7 @@ class DataFrameIterator(Iterator):
             classes = self.df[y_col].values
             self.classes = np.array([self.class_indices[cls] for cls in classes])
         elif class_mode == "other":
-            self.data = self.df[y_col].values
+            self._data = self.df[y_col].values
             if type(y_col) == str:
                 y_col = [y_col]
             if "object" in list(self.df[y_col].dtypes):
@@ -153,60 +153,6 @@ class DataFrameIterator(Iterator):
                                                 shuffle,
                                                 seed)
 
-    def _get_batches_of_transformed_samples(self, index_array):
-        batch_x = np.zeros(
-            (len(index_array),) + self.image_shape,
-            dtype=self.dtype)
-        # build batch of image data
-        for i, j in enumerate(index_array):
-            fname = self.filenames[j]
-            if self.directory is not None:
-                img_path = os.path.join(self.directory, fname)
-            else:
-                img_path = fname
-            img = load_img(img_path,
-                           color_mode=self.color_mode,
-                           target_size=self.target_size,
-                           interpolation=self.interpolation)
-            x = img_to_array(img, data_format=self.data_format)
-            # Pillow images should be closed after `load_img`,
-            # but not PIL images.
-            if hasattr(img, 'close'):
-                img.close()
-            if self.image_data_generator:
-                params = self.image_data_generator.get_random_transform(x.shape)
-                x = self.image_data_generator.apply_transform(x, params)
-                x = self.image_data_generator.standardize(x)
-            batch_x[i] = x
-        # optionally save augmented images to disk for debugging purposes
-        if self.save_to_dir:
-            for i, j in enumerate(index_array):
-                img = array_to_img(batch_x[i], self.data_format, scale=True)
-                fname = '{prefix}_{index}_{hash}.{format}'.format(
-                    prefix=self.save_prefix,
-                    index=j,
-                    hash=np.random.randint(1e7),
-                    format=self.save_format)
-                img.save(os.path.join(self.save_to_dir, fname))
-        # build batch of labels
-        if self.class_mode == 'input':
-            batch_y = batch_x.copy()
-        elif self.class_mode == 'sparse':
-            batch_y = self.classes[index_array]
-        elif self.class_mode == 'binary':
-            batch_y = self.classes[index_array].astype(self.dtype)
-        elif self.class_mode == 'categorical':
-            batch_y = np.zeros(
-                (len(batch_x), self.num_classes),
-                dtype=self.dtype)
-            for i, label in enumerate(self.classes[index_array]):
-                batch_y[i, label] = 1.
-        elif self.class_mode == 'other':
-            batch_y = self.data[index_array]
-        else:
-            return batch_x
-        return batch_x, batch_y
-
     def _filter_valid_filepaths(self, df):
         """Keep only dataframe rows with valid filenames
 
@@ -222,3 +168,16 @@ class DataFrameIterator(Iterator):
         format_check = filepaths.map(get_extension).isin(self.white_list_formats)
         existence_check = filepaths.map(os.path.isfile)
         return df[format_check & existence_check]
+
+    @property
+    def filepaths(self):
+        root = self.directory or ''
+        return [os.path.join(root, fname) for fname in self.filenames]
+
+    @property
+    def labels(self):
+        return self.classes
+
+    @property
+    def data(self):
+        return self._data

--- a/keras_preprocessing/image/dataframe_iterator.py
+++ b/keras_preprocessing/image/dataframe_iterator.py
@@ -14,7 +14,7 @@ from .utils import (array_to_img,
                     load_img)
 
 
-class DataFrameIterator(Iterator, BatchFromFilesMixin):
+class DataFrameIterator(BatchFromFilesMixin, Iterator):
     """Iterator capable of reading images from a directory on disk
         through a dataframe.
 

--- a/keras_preprocessing/image/directory_iterator.py
+++ b/keras_preprocessing/image/directory_iterator.py
@@ -17,7 +17,7 @@ from .utils import (array_to_img,
                     load_img)
 
 
-class DirectoryIterator(Iterator, BatchFromFilesMixin):
+class DirectoryIterator(BatchFromFilesMixin, Iterator):
     """Iterator capable of reading images from a directory on disk.
 
     # Arguments

--- a/keras_preprocessing/image/directory_iterator.py
+++ b/keras_preprocessing/image/directory_iterator.py
@@ -142,49 +142,10 @@ class DirectoryIterator(Iterator):
                                                 shuffle,
                                                 seed)
 
-    def _get_batches_of_transformed_samples(self, index_array):
-        batch_x = np.zeros(
-            (len(index_array),) + self.image_shape,
-            dtype=self.dtype)
-        # build batch of image data
-        for i, j in enumerate(index_array):
-            fname = self.filenames[j]
-            img = load_img(os.path.join(self.directory, fname),
-                           color_mode=self.color_mode,
-                           target_size=self.target_size,
-                           interpolation=self.interpolation)
-            x = img_to_array(img, data_format=self.data_format)
-            # Pillow images should be closed after `load_img`,
-            # but not PIL images.
-            if hasattr(img, 'close'):
-                img.close()
-            params = self.image_data_generator.get_random_transform(x.shape)
-            x = self.image_data_generator.apply_transform(x, params)
-            x = self.image_data_generator.standardize(x)
-            batch_x[i] = x
-        # optionally save augmented images to disk for debugging purposes
-        if self.save_to_dir:
-            for i, j in enumerate(index_array):
-                img = array_to_img(batch_x[i], self.data_format, scale=True)
-                fname = '{prefix}_{index}_{hash}.{format}'.format(
-                    prefix=self.save_prefix,
-                    index=j,
-                    hash=np.random.randint(1e7),
-                    format=self.save_format)
-                img.save(os.path.join(self.save_to_dir, fname))
-        # build batch of labels
-        if self.class_mode == 'input':
-            batch_y = batch_x.copy()
-        elif self.class_mode == 'sparse':
-            batch_y = self.classes[index_array]
-        elif self.class_mode == 'binary':
-            batch_y = self.classes[index_array].astype(self.dtype)
-        elif self.class_mode == 'categorical':
-            batch_y = np.zeros(
-                (len(batch_x), self.num_classes),
-                dtype=self.dtype)
-            for i, label in enumerate(self.classes[index_array]):
-                batch_y[i, label] = 1.
-        else:
-            return batch_x
-        return batch_x, batch_y
+    @property
+    def filepaths(self):
+        return [os.path.join(self.directory, fname) for fname in self.filenames]
+
+    @property
+    def labels(self):
+        return self.classes

--- a/keras_preprocessing/image/directory_iterator.py
+++ b/keras_preprocessing/image/directory_iterator.py
@@ -10,14 +10,14 @@ from six.moves import range
 
 import numpy as np
 
-from .iterator import Iterator
+from .iterator import BatchFromFilesMixin, Iterator
 from .utils import (array_to_img,
                     img_to_array,
                     _list_valid_filenames_in_directory,
                     load_img)
 
 
-class DirectoryIterator(Iterator):
+class DirectoryIterator(Iterator, BatchFromFilesMixin):
     """Iterator capable of reading images from a directory on disk.
 
     # Arguments
@@ -83,15 +83,15 @@ class DirectoryIterator(Iterator):
                  subset=None,
                  interpolation='nearest',
                  dtype='float32'):
-        super(DirectoryIterator, self).common_init(image_data_generator,
-                                                   target_size,
-                                                   color_mode,
-                                                   data_format,
-                                                   save_to_dir,
-                                                   save_prefix,
-                                                   save_format,
-                                                   subset,
-                                                   interpolation)
+        super(DirectoryIterator, self).set_processing_attrs(image_data_generator,
+                                                            target_size,
+                                                            color_mode,
+                                                            data_format,
+                                                            save_to_dir,
+                                                            save_prefix,
+                                                            save_format,
+                                                            subset,
+                                                            interpolation)
         self.directory = directory
         self.classes = classes
         if class_mode not in self.allowed_class_modes:

--- a/keras_preprocessing/image/iterator.py
+++ b/keras_preprocessing/image/iterator.py
@@ -174,6 +174,7 @@ class Iterator(IteratorType):
             (len(index_array),) + self.image_shape,
             dtype=self.dtype)
         # build batch of image data
+        # self.filepaths is dynamic, is better to call it once outside the loop
         filepaths = self.filepaths
         for i, j in enumerate(index_array):
             img = load_img(filepaths[j],
@@ -221,6 +222,7 @@ class Iterator(IteratorType):
 
     @property
     def filepaths(self):
+        """List of absolute paths to image files"""
         raise NotImplementedError(
             '`filepaths` property method has not been implemented in {}.'
             .format(type(self).__name__)
@@ -228,6 +230,7 @@ class Iterator(IteratorType):
 
     @property
     def labels(self):
+        """Class labels of every observation"""
         raise NotImplementedError(
             '`labels` property method has not been implemented in {}.'
             .format(type(self).__name__)

--- a/keras_preprocessing/image/iterator.py
+++ b/keras_preprocessing/image/iterator.py
@@ -149,17 +149,6 @@ class Iterator(IteratorType):
     def __next__(self, *args, **kwargs):
         return self.next(*args, **kwargs)
 
-    def _get_batches_of_transformed_samples(self, index_array):
-        """Gets a batch of transformed samples.
-
-        # Arguments
-            index_array: Array of sample indices to include in batch.
-
-        # Returns
-            A batch of transformed samples.
-        """
-        raise NotImplementedError
-
     def next(self):
         """For python 2.x.
 
@@ -173,6 +162,14 @@ class Iterator(IteratorType):
         return self._get_batches_of_transformed_samples(index_array)
 
     def _get_batches_of_transformed_samples(self, index_array):
+        """Gets a batch of transformed samples.
+
+        # Arguments
+            index_array: Array of sample indices to include in batch.
+
+        # Returns
+            A batch of transformed samples.
+        """
         batch_x = np.zeros(
             (len(index_array),) + self.image_shape,
             dtype=self.dtype)

--- a/keras_preprocessing/image/iterator.py
+++ b/keras_preprocessing/image/iterator.py
@@ -123,6 +123,10 @@ class Iterator(IteratorType):
 
 
 class BatchFromFilesMixin():
+    """Adds methods related to getting batches from filenames
+
+    It includes the logic to transform image files to batches.
+    """
 
     def set_processing_attrs(self,
                              image_data_generator,
@@ -134,6 +138,32 @@ class BatchFromFilesMixin():
                              save_format,
                              subset,
                              interpolation):
+        """Sets attributes to use later for processing files into a batch.
+
+        # Arguments
+            image_data_generator: Instance of `ImageDataGenerator`
+                to use for random transformations and normalization.
+            target_size: tuple of integers, dimensions to resize input images to.
+            color_mode: One of `"rgb"`, `"rgba"`, `"grayscale"`.
+                Color mode to read images.
+            data_format: String, one of `channels_first`, `channels_last`.
+            save_to_dir: Optional directory where to save the pictures
+                being yielded, in a viewable format. This is useful
+                for visualizing the random transformations being
+                applied, for debugging purposes.
+            save_prefix: String prefix to use for saving sample
+                images (if `save_to_dir` is set).
+            save_format: Format to use for saving sample images
+                (if `save_to_dir` is set).
+            subset: Subset of data (`"training"` or `"validation"`) if
+                validation_split is set in ImageDataGenerator.
+            interpolation: Interpolation method used to resample the image if the
+                target size is different from that of the loaded image.
+                Supported methods are "nearest", "bilinear", and "bicubic".
+                If PIL version 1.1.3 or newer is installed, "lanczos" is also
+                supported. If PIL version 3.4.0 or newer is installed, "box" and
+                "hamming" are also supported. By default, "nearest" is used.
+        """
         self.image_data_generator = image_data_generator
         self.target_size = tuple(target_size)
         if color_mode not in {'rgb', 'rgba', 'grayscale'}:

--- a/keras_preprocessing/image/iterator.py
+++ b/keras_preprocessing/image/iterator.py
@@ -63,57 +63,6 @@ class Iterator(IteratorType):
                                        self.batch_size * (idx + 1)]
         return self._get_batches_of_transformed_samples(index_array)
 
-    def common_init(self,
-                    image_data_generator,
-                    target_size,
-                    color_mode,
-                    data_format,
-                    save_to_dir,
-                    save_prefix,
-                    save_format,
-                    subset,
-                    interpolation):
-        self.image_data_generator = image_data_generator
-        self.target_size = tuple(target_size)
-        if color_mode not in {'rgb', 'rgba', 'grayscale'}:
-            raise ValueError('Invalid color mode:', color_mode,
-                             '; expected "rgb", "rgba", or "grayscale".')
-        self.color_mode = color_mode
-        self.data_format = data_format
-        if self.color_mode == 'rgba':
-            if self.data_format == 'channels_last':
-                self.image_shape = self.target_size + (4,)
-            else:
-                self.image_shape = (4,) + self.target_size
-        elif self.color_mode == 'rgb':
-            if self.data_format == 'channels_last':
-                self.image_shape = self.target_size + (3,)
-            else:
-                self.image_shape = (3,) + self.target_size
-        else:
-            if self.data_format == 'channels_last':
-                self.image_shape = self.target_size + (1,)
-            else:
-                self.image_shape = (1,) + self.target_size
-        self.save_to_dir = save_to_dir
-        self.save_prefix = save_prefix
-        self.save_format = save_format
-        self.interpolation = interpolation
-        if subset is not None:
-            validation_split = self.image_data_generator._validation_split
-            if subset == 'validation':
-                split = (0, validation_split)
-            elif subset == 'training':
-                split = (validation_split, 1)
-            else:
-                raise ValueError(
-                    'Invalid subset name: %s;'
-                    'expected "training" or "validation"' % (subset,))
-        else:
-            split = None
-        self.split = split
-        self.subset = subset
-
     def __len__(self):
         return (self.n + self.batch_size - 1) // self.batch_size  # round up
 
@@ -160,6 +109,60 @@ class Iterator(IteratorType):
         # The transformation of images is not under thread lock
         # so it can be done in parallel
         return self._get_batches_of_transformed_samples(index_array)
+
+
+class BatchFromFilesMixin():
+
+    def set_processing_attrs(self,
+                             image_data_generator,
+                             target_size,
+                             color_mode,
+                             data_format,
+                             save_to_dir,
+                             save_prefix,
+                             save_format,
+                             subset,
+                             interpolation):
+        self.image_data_generator = image_data_generator
+        self.target_size = tuple(target_size)
+        if color_mode not in {'rgb', 'rgba', 'grayscale'}:
+            raise ValueError('Invalid color mode:', color_mode,
+                             '; expected "rgb", "rgba", or "grayscale".')
+        self.color_mode = color_mode
+        self.data_format = data_format
+        if self.color_mode == 'rgba':
+            if self.data_format == 'channels_last':
+                self.image_shape = self.target_size + (4,)
+            else:
+                self.image_shape = (4,) + self.target_size
+        elif self.color_mode == 'rgb':
+            if self.data_format == 'channels_last':
+                self.image_shape = self.target_size + (3,)
+            else:
+                self.image_shape = (3,) + self.target_size
+        else:
+            if self.data_format == 'channels_last':
+                self.image_shape = self.target_size + (1,)
+            else:
+                self.image_shape = (1,) + self.target_size
+        self.save_to_dir = save_to_dir
+        self.save_prefix = save_prefix
+        self.save_format = save_format
+        self.interpolation = interpolation
+        if subset is not None:
+            validation_split = self.image_data_generator._validation_split
+            if subset == 'validation':
+                split = (0, validation_split)
+            elif subset == 'training':
+                split = (validation_split, 1)
+            else:
+                raise ValueError(
+                    'Invalid subset name: %s;'
+                    'expected "training" or "validation"' % (subset,))
+        else:
+            split = None
+        self.split = split
+        self.subset = subset
 
     def _get_batches_of_transformed_samples(self, index_array):
         """Gets a batch of transformed samples.

--- a/keras_preprocessing/image/iterator.py
+++ b/keras_preprocessing/image/iterator.py
@@ -110,6 +110,17 @@ class Iterator(IteratorType):
         # so it can be done in parallel
         return self._get_batches_of_transformed_samples(index_array)
 
+    def _get_batches_of_transformed_samples(self, index_array):
+        """Gets a batch of transformed samples.
+
+        # Arguments
+            index_array: Array of sample indices to include in batch.
+
+        # Returns
+            A batch of transformed samples.
+        """
+        raise NotImplementedError
+
 
 class BatchFromFilesMixin():
 

--- a/keras_preprocessing/image/iterator.py
+++ b/keras_preprocessing/image/iterator.py
@@ -174,7 +174,7 @@ class Iterator(IteratorType):
             (len(index_array),) + self.image_shape,
             dtype=self.dtype)
         # build batch of image data
-        fielpaths = self.filepaths
+        filepaths = self.filepaths
         for i, j in enumerate(index_array):
             img = load_img(filepaths[j],
                            color_mode=self.color_mode,
@@ -221,12 +221,21 @@ class Iterator(IteratorType):
 
     @property
     def filepaths(self):
-        raise NotImplementedError('filepaths property has not been implemented.')
+        raise NotImplementedError(
+            '`filepaths` property method has not been implemented in {}.'
+            .format(type(self).__name__)
+        )
 
     @property
     def labels(self):
-        raise NotImplementedError('labels property has not been implemented.')
+        raise NotImplementedError(
+            '`labels` property method has not been implemented in {}.'
+            .format(type(self).__name__)
+        )
 
     @property
     def data(self):
-        raise NotImplementedError('data property has not been implemented.')
+        raise NotImplementedError(
+            '`data` property method has not been implemented in {}.'
+            .format(type(self).__name__)
+        )


### PR DESCRIPTION
### Summary
Currently both `DataFrameIterator` and `DirectoryIterator` contain the `_get_batches_of_transformed_samples` and `common_init` method, but both classes methods do the same thing, and the logic is slightly different. This PR merges both method versions and adds them to a Mixin class `BatchFromFilesMixin`. It needs to be a Mixin and not in the `Iterator` class because `NumpyIterator` does not use them. This PR avoid this code duplication and in my opinion also simplifies the logic a little bit by stating that is enough to collect `filepaths` and `labels` from to make things work, which makes sense. Therefore both `filepaths` and `labels` are declared as properties and an `NotImplementedError` is raised if not overwritten by the child class.

@Dref360, After @Vijayabhaskar96 pointed out some problems with PR #127 so I closed it. This PR does what #127 was doing plus some.

### PR Overview

- [n] This PR requires new unit tests [y/n] (make sure tests are included)
- [n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)