### PR TITLE
Remove next method from NumpyIterator

### DIFF
--- a/keras_preprocessing/image/numpy_array_iterator.py
+++ b/keras_preprocessing/image/numpy_array_iterator.py
@@ -172,17 +172,3 @@ class NumpyArrayIterator(Iterator):
         if self.sample_weight is not None:
             output += (self.sample_weight[index_array],)
         return output
-
-    def next(self):
-        """For python 2.x.
-
-        # Returns
-            The next batch.
-        """
-        # Keeps under lock only the mechanism which advances
-        # the indexing of each batch.
-        with self.lock:
-            index_array = next(self.index_generator)
-        # The transformation of images is not under thread lock
-        # so it can be done in parallel
-        return self._get_batches_of_transformed_samples(index_array)


### PR DESCRIPTION
### Summary
This PR removes the `next` method in `NumpyIterator` since it's already in the base class `Iterator`.

### PR Overview

- [n ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [ y] This PR is backwards compatible [y/n]
- [ n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
