### PR TITLE
Numpy labels

### DIFF
--- a/keras_preprocessing/image/numpy_array_iterator.py
+++ b/keras_preprocessing/image/numpy_array_iterator.py
@@ -89,9 +89,9 @@ class NumpyArrayIterator(Iterator):
                                  '; expected "training" or "validation".')
             split_idx = int(len(x) * image_data_generator._validation_split)
 
-            if not np.array_equal(
-                    np.unique(y[:split_idx]),
-                    np.unique(y[split_idx:])):
+            if (y and not
+                np.array_equal(np.unique(y[:split_idx]),
+                               np.unique(y[split_idx:]))):
                 raise ValueError('Training and validation subsets '
                                  'have different number of classes after '
                                  'the split. If your numpy arrays are '

--- a/keras_preprocessing/image/numpy_array_iterator.py
+++ b/keras_preprocessing/image/numpy_array_iterator.py
@@ -89,7 +89,7 @@ class NumpyArrayIterator(Iterator):
                                  '; expected "training" or "validation".')
             split_idx = int(len(x) * image_data_generator._validation_split)
 
-            if (y and not
+            if (y is not None and not
                 np.array_equal(np.unique(y[:split_idx]),
                                np.unique(y[split_idx:]))):
                 raise ValueError('Training and validation subsets '

--- a/tests/image_test.py
+++ b/tests/image_test.py
@@ -158,6 +158,11 @@ class TestImage(object):
             assert (x[1] == x_misc1[:3]).all()
             assert (x[2] == x_misc2[:3]).all()
 
+            generator = image.ImageDataGenerator(validation_split=0.2)
+            x = generator.flow(images, batch_size=3).next()
+            assert isinstance(x, np.ndarray)
+            assert x.shape == images[:3].shape
+
             # Test some failure cases:
             x_misc_err = np.random.random((dsize + 1, 3, 3))
 


### PR DESCRIPTION
### Summary
ImageDataGenerator breaks when used with a validation_split and no labels

```
from keras_preprocessing.image import ImageDataGenerator
import numpy as np

ImageDataGenerator(validation_split=0.2).flow(x=np.random.normal(size=(100, 30, 30, 3)), subset='validation').next()
```

### Related Issues
Solves #129 

### PR Overview

- [ y] This PR requires new unit tests [y/n] (make sure tests are included)
- [ n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [ y] This PR is backwards compatible [y/n]
- [ n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
