### PR TITLE
Multi label

### DIFF
--- a/keras_preprocessing/image/dataframe_iterator.py
+++ b/keras_preprocessing/image/dataframe_iterator.py
@@ -49,16 +49,19 @@ class DataFrameIterator(BatchFromFilesMixin, Iterator):
             Color mode to read images.
         classes: Optional list of strings, classes to use (e.g. `["dogs", "cats"]`).
             If None, all classes in `y_col` will be used.
-        class_mode: Mode for yielding the targets:
-            `"binary"`: binary targets (if there are only two classes),
-            `"categorical"`: categorical targets, supports multi-label output
-                if class values per observation are stored in a list or tuple
-                in the `y_col` column,
-            `"sparse"`: integer targets,
-            `"input"`: targets are images identical to input images (mainly
-                used to work with autoencoders),
-            `"other"`: targets are the data(numpy array) of y_col data
-            `None`: no targets get yielded (only input images are yielded).
+        class_mode: one of "categorical", "binary", "sparse", "input",
+            "other" or None. Default: "categorical".
+            Mode for yielding the targets:
+            - `"binary"`: 1D numpy array of binary labels,
+            - `"categorical"`: 2D numpy array of one-hot encoded labels.
+                Supports multi-label output.
+            - `"sparse"`: 1D numpy array of integer labels,
+            - `"input"`: images identical to input images (mainly used to
+                work with autoencoders),
+            - `"other"`: numpy array of `y_col` data,
+            - `None`, no targets are returned (the generator will only yield
+                batches of image data, which is useful to use in
+            `model.predict_generator()`, `model.evaluate_generator()`, etc.).
         batch_size: Integer, size of a batch.
         shuffle: Boolean, whether to shuffle the data between epochs.
         seed: Random seed for data shuffling.

--- a/keras_preprocessing/image/dataframe_iterator.py
+++ b/keras_preprocessing/image/dataframe_iterator.py
@@ -170,8 +170,7 @@ class DataFrameIterator(BatchFromFilesMixin, Iterator):
         if not all(df[x_col].apply(lambda x: isinstance(x, str))):
             raise ValueError('All values in column x_col={} must be strings.'
                              .format(x_col))
-        # check labels are string or numeric if class_mode is binary or sparse
-        # Note: categorical class_mode supports numeric, string, list and tuple
+        # check labels are string if class_mode is binary or sparse
         if self.class_mode in {'binary', 'sparse'}:
             if not all(df[y_col].apply(lambda x: isinstance(x, str))):
                 raise TypeError('If class_mode="{}", y_col="{}" column '
@@ -188,14 +187,14 @@ class DataFrameIterator(BatchFromFilesMixin, Iterator):
             elif df[y_col].nunique() != 2:
                 raise ValueError('If class_mode="binary" there must be 2 classes. '
                                  'Found {} classes.'.format(df[y_col].nunique()))
-
+        # check values are string, list or tuple if class_mode is categorical
         if self.class_mode == 'categorical':
             types = (str, list, tuple)
             if not all(df[y_col].apply(lambda x: isinstance(x, types))):
                 raise TypeError('If class_mode="{}", y_col="{}" column '
                                 'values must be type string, list or tuple.'
                                 .format(self.class_mode, y_col))
-        # check that no classes are given if class_mode other or input
+        # raise warning if classes are given and class_mode other or input
         if classes and self.class_mode in {"other", "input", None}:
             warnings.warn('`classes` will be ignored given the class_mode="{}"'
                           .format(self.class_mode))

--- a/keras_preprocessing/image/dataframe_iterator.py
+++ b/keras_preprocessing/image/dataframe_iterator.py
@@ -61,7 +61,7 @@ class DataFrameIterator(BatchFromFilesMixin, Iterator):
             - `"other"`: numpy array of `y_col` data,
             - `None`, no targets are returned (the generator will only yield
                 batches of image data, which is useful to use in
-            `model.predict_generator()`, `model.evaluate_generator()`, etc.).
+                `model.predict_generator()`).
         batch_size: Integer, size of a batch.
         shuffle: Boolean, whether to shuffle the data between epochs.
         seed: Random seed for data shuffling.

--- a/keras_preprocessing/image/dataframe_iterator.py
+++ b/keras_preprocessing/image/dataframe_iterator.py
@@ -93,6 +93,7 @@ class DataFrameIterator(BatchFromFilesMixin, Iterator):
                  interpolation='nearest',
                  dtype='float32',
                  drop_duplicates=True):
+
         super(DataFrameIterator, self).set_processing_attrs(image_data_generator,
                                                             target_size,
                                                             color_mode,
@@ -102,7 +103,7 @@ class DataFrameIterator(BatchFromFilesMixin, Iterator):
                                                             save_format,
                                                             subset,
                                                             interpolation)
-        self.df = dataframe.copy()
+        df = dataframe.copy()
         if drop_duplicates:
             self.df.drop_duplicates(x_col, inplace=True)
         self.x_col = x_col
@@ -155,6 +156,7 @@ class DataFrameIterator(BatchFromFilesMixin, Iterator):
 
     @staticmethod
     def _filter_classes(self, df, x_col, classes):
+        df = df.copy()
 
         def remove_classes(labels, classes):
             if isinstance(labels, (list, tuple)):

--- a/keras_preprocessing/image/dataframe_iterator.py
+++ b/keras_preprocessing/image/dataframe_iterator.py
@@ -106,11 +106,10 @@ class DataFrameIterator(BatchFromFilesMixin, Iterator):
         df = dataframe.copy()
         if drop_duplicates:
             df.drop_duplicates(x_col, inplace=True)
-        df, classes = _filter_classes(self, df, y_col, classes)
+        classes = classes or []
+        if class_mode not in ["other", "input", None]:
+            df, classes = _filter_classes(self, df, y_col, classes)
         self.directory = directory
-        if class_mode not in self.allowed_class_modes:
-            raise ValueError('Invalid class_mode: {}; expected one of: {}'
-                             .format(class_mode, self.allowed_class_modes))
         self.class_mode = class_mode
         self.dtype = dtype
         self.num_classes = len(classes)

--- a/keras_preprocessing/image/dataframe_iterator.py
+++ b/keras_preprocessing/image/dataframe_iterator.py
@@ -146,7 +146,7 @@ class DataFrameIterator(BatchFromFilesMixin, Iterator):
         self.filenames = df[x_col].tolist()
         # create numpy array of raw input if class_mode="other"
         if class_mode == "other":
-            self.data = df[y_col].values
+            self._data = df[y_col].values
             if isinstance(y_col, str):
                 y_col = [y_col]
             if "object" in list(df[y_col].dtypes):

--- a/keras_preprocessing/image/dataframe_iterator.py
+++ b/keras_preprocessing/image/dataframe_iterator.py
@@ -41,7 +41,9 @@ class DataFrameIterator(BatchFromFilesMixin, Iterator):
             It will be computed automatically if not set.
         class_mode: Mode for yielding the targets:
             `"binary"`: binary targets (if there are only two classes),
-            `"categorical"`: categorical targets,
+            `"categorical"`: categorical targets, supports multi-label output
+                if class values per observation are stored in a list or tuple
+                in the y_col column,
             `"sparse"`: integer targets,
             `"input"`: targets are images identical to input images (mainly
                 used to work with autoencoders),
@@ -119,14 +121,17 @@ class DataFrameIterator(BatchFromFilesMixin, Iterator):
             num_classes = len(classes)
             # build an index of all the unique classes
             self.class_indices = dict(zip(classes, range(len(classes))))
+        # retrieve only training or validation set
         if self.split:
             num_files = len(df)
             start = int(self.split[0] * num_files)
             stop = int(self.split[1] * num_files)
             df = df.iloc[start: stop, :]
+        # get labels for each observation
         if class_mode not in ["other", "input", None]:
             self.classes = self.get_classes(df, y_col)
         self.filenames = df[x_col].tolist()
+        # create numpy array of raw input if class_mode="other"
         if class_mode == "other":
             self.data = df[y_col].values
             if isinstance(y_col, str):

--- a/keras_preprocessing/image/dataframe_iterator.py
+++ b/keras_preprocessing/image/dataframe_iterator.py
@@ -30,8 +30,8 @@ class DataFrameIterator(BatchFromFilesMixin, Iterator):
         image_data_generator: Instance of `ImageDataGenerator` to use for
             random transformations and normalization. If None, no transformations
             and normalizations are made.
-        x_col: Column in dataframe that contains all the filenames (or absolute
-            paths, if directory is set to None).
+        x_col: string, column in dataframe that contains the filenames (or absolute
+            paths, if directory is None).
         y_col: Column/s in dataframe that has the target data.
         target_size: tuple of integers, dimensions to resize input images to.
         color_mode: One of `"rgb"`, `"rgba"`, `"grayscale"`.
@@ -224,6 +224,7 @@ class DataFrameIterator(BatchFromFilesMixin, Iterator):
 
         # Arguments
             df: Pandas dataframe containing filenames in a column
+            x_col: string, column in `df` that contains the filenames or filepaths
 
         # Returns
             absolute paths to image files

--- a/keras_preprocessing/image/dataframe_iterator.py
+++ b/keras_preprocessing/image/dataframe_iterator.py
@@ -105,42 +105,33 @@ class DataFrameIterator(BatchFromFilesMixin, Iterator):
                                                             interpolation)
         df = dataframe.copy()
         if drop_duplicates:
-            self.df.drop_duplicates(x_col, inplace=True)
-        self.x_col = x_col
+            df.drop_duplicates(x_col, inplace=True)
+        df, classes = _filter_classes(self, df, y_col, classes)
         self.directory = directory
-        df, self.classes = self._filter_classes(df, x_col, classes)
         if class_mode not in self.allowed_class_modes:
             raise ValueError('Invalid class_mode: {}; expected one of: {}'
                              .format(class_mode, self.allowed_class_modes))
         self.class_mode = class_mode
         self.dtype = dtype
-
-        if not classes:
-            classes = []
-            if class_mode not in ["other", "input", None]:
-                classes = list(np.sort(self.df[y_col].unique()))
-        else:
-            if class_mode in ["other", "input", None]:
-                raise ValueError('classes cannot be set if class_mode'
-                                 ' is either "other" or "input" or None.')
         self.num_classes = len(classes)
+        # build an index of all the unique classes
         self.class_indices = dict(zip(classes, range(len(classes))))
-        self.df = self._filter_valid_filepaths(self.df)
+        # check which image files are valid and keep them
+        df = self._filter_valid_filepaths(df)
         if self.split:
-            num_files = len(self.df)
+            num_files = len(df)
             start = int(self.split[0] * num_files)
             stop = int(self.split[1] * num_files)
-            self.df = self.df.iloc[start: stop, :]
-        self.filenames = self.df[x_col].tolist()
+            df = df.iloc[start: stop, :]
+        self.filenames = df[x_col].tolist()
 
         if class_mode not in ["other", "input", None]:
-            classes = self.df[y_col].values
-            self.classes = np.array([self.class_indices[cls] for cls in classes])
-        elif class_mode == "other":
-            self._data = self.df[y_col].values
+            classes = df[y_col].values
+        if class_mode == "other":
+            self._data = df[y_col].values
             if type(y_col) == str:
                 y_col = [y_col]
-            if "object" in list(self.df[y_col].dtypes):
+            if "object" in list(df[y_col].dtypes):
                 raise TypeError("y_col column/s must be numeric datatypes.")
         self.samples = len(self.filenames)
         if self.num_classes > 0:
@@ -155,7 +146,7 @@ class DataFrameIterator(BatchFromFilesMixin, Iterator):
                                                 seed)
 
     @staticmethod
-    def _filter_classes(self, df, x_col, classes):
+    def _filter_classes(self, df, y_col, classes):
         df = df.copy()
 
         def remove_classes(labels, classes):
@@ -167,20 +158,20 @@ class DataFrameIterator(BatchFromFilesMixin, Iterator):
             else:
                 raise TypeError(
                     "Expect string, list or tuple but found {} in {} column "
-                    .format(type(x), x_col)
+                    .format(type(x), y_col)
                 )
 
         if classes:
             classes = set(classes)  # sort and prepare for membership lookup
-            df[x_col] = df[x_col].apply(lambda x: remove_classes(x, classes))
+            df[y_col] = df[y_col].apply(lambda x: remove_classes(x, classes))
         else:
             classes = set()
-            for v in df[x_col]:
+            for v in df[y_col]:
                 if isinstance(v, (list, tuple)):
                     classes.update(v)
                 else:
                     classes.add(v)
-        return df.dropna(subset=[x_col]), sorted(classes)
+        return df.dropna(subset=[y_col]), sorted(classes)
 
     def _filter_valid_filepaths(self, df):
         """Keep only dataframe rows with valid filenames

--- a/keras_preprocessing/image/dataframe_iterator.py
+++ b/keras_preprocessing/image/dataframe_iterator.py
@@ -27,22 +27,21 @@ class DataFrameIterator(BatchFromFilesMixin, Iterator):
             images in a string column. It should include other column/s
             depending on the `class_mode`:
                 - if `class_mode` is `"categorical"` (default value) it must
-                include the `y_col` column with the class/es of each image.
-                Values in column can be string/list/tuple if a single class
-                or list/tuple if multiple classes.
+                    include the `y_col` column with the class/es of each image.
+                    Values in column can be string/list/tuple if a single class
+                    or list/tuple if multiple classes.
                 - if `class_mode` is `"binary"` or `"sparse"` it must include
-                the given `y_col` column with class values as strings.
+                    the given `y_col` column with class values as strings.
                 - if `class_mode` is `"other"` it should contain the columns
-                specified in `y_col`.
-                - if `class_mode` is `input` or None no extra column is needed.
-        directory: string, path to the directory to read images from. Directory to
-            under which all the images are present. If None, data in `x_col` column
-            should be absolute paths.
+                    specified in `y_col`.
+                - if `class_mode` is `"input"` or `None` no extra column is needed.
+        directory: string, path to the directory to read images from. If `None`,
+            data in `x_col` column should be absolute paths.
         image_data_generator: Instance of `ImageDataGenerator` to use for
             random transformations and normalization. If None, no transformations
             and normalizations are made.
         x_col: string, column in `dataframe` that contains the filenames (or
-            absolute paths if `directory` is None).
+            absolute paths if `directory` is `None`).
         y_col: string or list, column/s in `dataframe` that has the target data.
         target_size: tuple of integers, dimensions to resize input images to.
         color_mode: One of `"rgb"`, `"rgba"`, `"grayscale"`.

--- a/keras_preprocessing/image/dataframe_iterator.py
+++ b/keras_preprocessing/image/dataframe_iterator.py
@@ -25,25 +25,24 @@ class DataFrameIterator(BatchFromFilesMixin, Iterator):
             in a column and classes in another column/s that can be fed as raw
             target data.
         directory: string, path to the directory to read images from. Directory to
-            under which all the images are present. If None, data in x_col column
+            under which all the images are present. If None, data in `x_col` column
             should be absolute paths.
         image_data_generator: Instance of `ImageDataGenerator` to use for
             random transformations and normalization. If None, no transformations
             and normalizations are made.
-        x_col: string, column in dataframe that contains the filenames (or absolute
-            paths, if directory is None).
-        y_col: Column/s in dataframe that has the target data.
+        x_col: string, column in `dataframe` that contains the filenames (or
+            absolute paths if `directory` is None).
+        y_col: string or list, column/s in `dataframe` that has the target data.
         target_size: tuple of integers, dimensions to resize input images to.
         color_mode: One of `"rgb"`, `"rgba"`, `"grayscale"`.
             Color mode to read images.
-        classes: Optional list of strings, names of
-            each class (e.g. `["dogs", "cats"]`).
-            It will be computed automatically if not set.
+        classes: Optional list of strings, classes to use (e.g. `["dogs", "cats"]`).
+            If None, all classes in `y_col` will be used.
         class_mode: Mode for yielding the targets:
             `"binary"`: binary targets (if there are only two classes),
             `"categorical"`: categorical targets, supports multi-label output
                 if class values per observation are stored in a list or tuple
-                in the y_col column,
+                in the `y_col` column,
             `"sparse"`: integer targets,
             `"input"`: targets are images identical to input images (mainly
                 used to work with autoencoders),
@@ -158,8 +157,8 @@ class DataFrameIterator(BatchFromFilesMixin, Iterator):
         if not all(df[x_col].apply(lambda x: isinstance(x, str))):
             raise ValueError('All values in column x_col={} must be strings.'
                              .format(x_col))
-        # check that labels are string or numeric if binary and sparse output
-        # Note: sparse class_mode supports numeric, string, list and tuple
+        # check labels are string or numeric if class_mode is binary or sparse
+        # Note: categorical class_mode supports numeric, string, list and tuple
         if self.class_mode in {'binary', 'sparse'}:
             if not (is_numeric_dtype(df[y_col]) or
                     all(df[y_col].apply(lambda x: isinstance(x, str)))):
@@ -178,7 +177,7 @@ class DataFrameIterator(BatchFromFilesMixin, Iterator):
                 raise ValueError('If class_mode="binary" there must be 2 classes. '
                                  'Found {} classes.'.format(df[y_col].nunique()))
         # check that no classes are given if class_mode other or input
-        if classes and self.class_mode in ["other", "input", None]:
+        if classes and self.class_mode in {"other", "input", None}:
             raise ValueError('classes cannot be set if class_mode'
                              ' is either "other" or "input" or None.')
 

--- a/keras_preprocessing/image/image_data_generator.py
+++ b/keras_preprocessing/image/image_data_generator.py
@@ -570,22 +570,20 @@ class ImageDataGenerator(object):
                 images in a string column. It should include other column/s
                 depending on the `class_mode`:
                     - if `class_mode` is `"categorical"` (default value) it must
-                    include the `y_col` column with the class/es of each image.
-                    Values in column can be string/list/tuple if a single class
-                    or list/tuple if multiple classes.
+                        include the `y_col` column with the class/es of each image.
+                        Values in column can be string/list/tuple if a single class
+                        or list/tuple if multiple classes.
                     - if `class_mode` is `"binary"` or `"sparse"` it must include
-                    the given `y_col` column with class values as strings.
+                        the given `y_col` column with class values as strings.
                     - if `class_mode` is `"other"` it should contain the columns
-                    specified in `y_col`.
-                    - if `class_mode` is `input` or None no extra column is needed.
-            directory: string, path to the directory to read images from.
-                Directory to under which all the images are present. If None,
-                data in `x_col` column should be absolute paths. If None,
-                data in x_col column should be absolute paths.
-            x_col: string, column in the dataframe that contains
-                the filenames of the target images.
-            y_col: string or list of strings,columns in
-                the dataframe that will be the target data.
+                        specified in `y_col`.
+                    - if `class_mode` is `"input"` or `None` no extra column is
+                        needed.
+            directory: string, path to the directory to read images from. If `None`,
+                data in `x_col` column should be absolute paths.
+            x_col: string, column in `dataframe` that contains the filenames (or
+                absolute paths if `directory` is `None`).
+            y_col: string or list, column/s in `dataframe` that has the target data.
             target_size: tuple of integers `(height, width)`, default: `(256, 256)`.
                 The dimensions to which all images found will be resized.
             color_mode: one of "grayscale", "rgb". Default: "rgb".

--- a/keras_preprocessing/image/image_data_generator.py
+++ b/keras_preprocessing/image/image_data_generator.py
@@ -483,8 +483,7 @@ class ImageDataGenerator(object):
                     to input images (mainly used to work with autoencoders).
                 - If None, no labels are returned
                   (the generator will only yield batches of image data,
-                  which is useful to use with `model.predict_generator()`,
-                  `model.evaluate_generator()`, etc.).
+                  which is useful to use with `model.predict_generator()`).
                   Please note that in case of class_mode None,
                   the data still needs to reside in a subdirectory
                   of `directory` for it to work correctly.
@@ -607,9 +606,9 @@ class ImageDataGenerator(object):
                 - `"input"`: images identical to input images (mainly used to
                     work with autoencoders),
                 - `"other"`: numpy array of `y_col` data,
-                - `None`, no labels are returned (the generator will only yield
+                - `None`, no targets are returned (the generator will only yield
                     batches of image data, which is useful to use in
-                `model.predict_generator()`, `model.evaluate_generator()`, etc.).
+                    `model.predict_generator()`).
             batch_size: size of the batches of data (default: 32).
             shuffle: whether to shuffle the data (default: True)
             seed: optional random seed for shuffling and transformations.

--- a/keras_preprocessing/image/image_data_generator.py
+++ b/keras_preprocessing/image/image_data_generator.py
@@ -566,9 +566,23 @@ class ImageDataGenerator(object):
                                     http://bit.ly/keras_flow_from_dataframe).
 
         # Arguments
+            dataframe: Pandas dataframe containing the filepaths relative to
+                `directory` (or absolute paths if `directory` is None) of the
+                images in a string column. It should include other column/s
+                depending on the `class_mode`:
+                    - if `class_mode` is `"categorical"` (default value) it must
+                    include the `y_col` column with the class/es of each image.
+                    Values in column can be string/list/tuple if a single class
+                    or list/tuple if multiple classes.
+                    - if `class_mode` is `"binary"` or `"sparse"` it must include
+                    the given `y_col` column with class values as strings.
+                    - if `class_mode` is `"other"` it should contain the columns
+                    specified in `y_col`.
+                    - if `class_mode` is `input` or None no extra column is needed.
             directory: string, path to the directory to read images from.
-                Directory to under which all the images are present.
-                If None, data in x_col column should be absolute paths.
+                Directory to under which all the images are present. If None,
+                data in `x_col` column should be absolute paths. If None,
+                data in x_col column should be absolute paths.
             x_col: string, column in the dataframe that contains
                 the filenames of the target images.
             y_col: string or list of strings,columns in
@@ -583,17 +597,18 @@ class ImageDataGenerator(object):
                 which will map to the label indices, will be alphanumeric).
                 The dictionary containing the mapping from class names to class
                 indices can be obtained via the attribute `class_indices`.
-            class_mode: one of "categorical", "binary", "sparse",
-                "input", "other" or None. Default: "categorical".
-                Determines the type of label arrays that are returned:
-                - `"categorical"` will be 2D one-hot encoded labels,
-                - `"binary"` will be 1D binary labels,
-                - `"sparse"` will be 1D integer labels,
-                - `"input"` will be images identical
-                    to input images (mainly used to work with autoencoders).
-                - `"other"` will be numpy array of `y_col` data
-                - None, no labels are returned (the generator will only
-                    yield batches of image data, which is useful to use
+            class_mode: one of "categorical", "binary", "sparse", "input",
+                "other" or None. Default: "categorical".
+                Mode for yielding the targets:
+                - `"binary"`: 1D numpy array of binary labels,
+                - `"categorical"`: 2D numpy array of one-hot encoded labels.
+                    Supports multi-label output.
+                - `"sparse"`: 1D numpy array of integer labels,
+                - `"input"`: images identical to input images (mainly used to
+                    work with autoencoders),
+                - `"other"`: numpy array of `y_col` data,
+                - `None`, no labels are returned (the generator will only yield
+                    batches of image data, which is useful to use in
                 `model.predict_generator()`, `model.evaluate_generator()`, etc.).
             batch_size: size of the batches of data (default: 32).
             shuffle: whether to shuffle the data (default: True)

--- a/keras_preprocessing/image/iterator.py
+++ b/keras_preprocessing/image/iterator.py
@@ -261,7 +261,6 @@ class BatchFromFilesMixin():
             return batch_x
         return batch_x, batch_y
 
-
     @property
     def filepaths(self):
         """List of absolute paths to image files"""

--- a/keras_preprocessing/image/iterator.py
+++ b/keras_preprocessing/image/iterator.py
@@ -214,9 +214,7 @@ class BatchFromFilesMixin():
         # Returns
             A batch of transformed samples.
         """
-        batch_x = np.zeros(
-            (len(index_array),) + self.image_shape,
-            dtype=self.dtype)
+        batch_x = np.zeros((len(index_array),) + self.image_shape, dtype=self.dtype)
         # build batch of image data
         # self.filepaths is dynamic, is better to call it once outside the loop
         filepaths = self.filepaths
@@ -248,21 +246,21 @@ class BatchFromFilesMixin():
         # build batch of labels
         if self.class_mode == 'input':
             batch_y = batch_x.copy()
-        elif self.class_mode == 'sparse':
-            batch_y = self.classes[index_array]
-        elif self.class_mode == 'binary':
-            batch_y = self.classes[index_array].astype(self.dtype)
+        elif self.class_mode in {'binary', 'sparse'}:
+            batch_y = np.empty(len(batch_x), dtype=self.dtype)
+            for i, n_observation in enumerate(index_array):
+                batch_y[i] = self.classes[n_observation]
         elif self.class_mode == 'categorical':
-            batch_y = np.zeros(
-                (len(batch_x), len(set(self.labels))),
-                dtype=self.dtype)
-            for i, label in enumerate(self.labels[index_array]):
-                batch_y[i, label] = 1.
+            batch_y = np.zeros((len(batch_x), len(self.class_indices)),
+                               dtype=self.dtype)
+            for i, n_observation in enumerate(index_array):
+                batch_y[i, self.classes[n_observation]] = 1.
         elif self.class_mode == 'other':
             batch_y = self.data[index_array]
         else:
             return batch_x
         return batch_x, batch_y
+
 
     @property
     def filepaths(self):

--- a/tests/image_test.py
+++ b/tests/image_test.py
@@ -670,7 +670,6 @@ class TestImage(object):
             "class": [['b', 'a']] + ['b'] + [['c']] + [random.choice(label_opt)
                                                        for _ in filenames[:-3]]
         })
-        print(df)
         generator = image.ImageDataGenerator()
         df_iterator = generator.flow_from_dataframe(df, str(tmpdir), shuffle=False)
         batch_x, batch_y = next(df_iterator)

--- a/tests/image_test.py
+++ b/tests/image_test.py
@@ -502,7 +502,7 @@ class TestImage(object):
 
         df = pd.DataFrame({
             "filename": filenames,
-            "class": [random.randint(0, 1) for _ in filenames],
+            "class": [str(random.randint(0, 1)) for _ in filenames],
             "filepaths": filepaths
         })
 
@@ -553,7 +553,7 @@ class TestImage(object):
         _, batch_y = next(generator.flow_from_dataframe(df, str(tmpdir),
                                                         shuffle=False,
                                                         class_mode="sparse"))
-        assert (batch_y == df['class'].tolist()[:len(batch_y)]).all()
+        assert (batch_y == df['class'].astype('float')[:len(batch_y)]).all()
         # Test invalid use cases
         with pytest.raises(ValueError):
             generator.flow_from_dataframe(df, str(tmpdir), color_mode='cmyk')
@@ -707,7 +707,7 @@ class TestImage(object):
                 count += 1
 
         df = pd.DataFrame({"filename": filenames,
-                           "class": [random.randint(0, 1) for _ in filenames]})
+                           "class": [str(random.randint(0, 1)) for _ in filenames]})
         # create iterator
         generator = image.ImageDataGenerator(validation_split=validation_split)
         df_sparse_iterator = generator.flow_from_dataframe(df,
@@ -749,6 +749,7 @@ class TestImage(object):
 
         # create dataframes
         classes = np.random.randint(num_classes, size=len(filenames))
+        classes = [str(c) for c in classes]
         df = pd.DataFrame({"filename": filenames,
                            "class": classes})
         df2 = pd.DataFrame({"filename": filenames,
@@ -796,6 +797,7 @@ class TestImage(object):
 
         # create dataframes
         classes = np.random.randint(2, size=len(input_filenames))
+        classes = [str(c) for c in classes]
         df = pd.DataFrame({"filename": input_filenames})
         df2 = pd.DataFrame({"filename": input_filenames,
                             "class": classes})
@@ -830,6 +832,7 @@ class TestImage(object):
 
         # create dataframes
         classes = np.random.randint(2, size=len(file_paths))
+        classes = [str(c) for c in classes]
         df = pd.DataFrame({"filename": file_paths})
         df2 = pd.DataFrame({"filename": file_paths,
                             "class": classes})
@@ -953,6 +956,7 @@ class TestImage(object):
 
         # create dataframe
         classes = np.random.randint(num_classes, size=len(filenames))
+        classes = [str(c) for c in classes]
         df = pd.DataFrame({"filename": filenames,
                            "class": classes})
 


### PR DESCRIPTION
### Summary
At the moment there is no support for multi-label. This PR adds multi-label support.
Minimal example:
```
import numpy as np
import scipy.misc
import pandas as pd
import random
from keras_preprocessing.image import ImageDataGenerator
import matplotlib.pyplot as plt

pixel_val = 1
filenames = []
for i in range(30):
    filename = '/tmp/{}.jpg'.format(i)
    plt.imsave(filename, pixel_val * np.ones((3, 3, 3)))
    filenames.append(filename)

classes = ['dog', 'cat', ['dog', 'cat']] * 10
df = pd.DataFrame({'filename': filenames, 'class': classes}).sample(frac=1).reset_index(drop=True)

generator = ImageDataGenerator(rescale=1/255).flow_from_dataframe(
    df,
    batch_size=3,
    target_size=(3, 3),
    shuffle = False,
    classes=['non-existent', 'dog', 'cat'],
    class_mode='categorical',
)
assert next(generator)[1].shape == (3, 3)
```
The way to use it integrates seemingly to the current way of using it. The user can still use the `categorical` class mode but instead send several classes per observation in a form of a list or tuple. It will just work.

There is indeed some additional boiler plate for checking inputs and parameters, there were already some before but now they have moved to the top of the function and to a separate method logic.

### Related Issues
#135 

### PR Overview

- [ y] This PR requires new unit tests [y/n] (make sure tests are included)
- [ y] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [ y] This PR is backwards compatible [y/n]
- [ n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
