### PR TITLE
Refactor standardize

### DIFF
--- a/keras_preprocessing/image/image_data_generator.py
+++ b/keras_preprocessing/image/image_data_generator.py
@@ -668,7 +668,15 @@ class ImageDataGenerator(object):
         )
 
     def standardize(self, x):
-        """Applies the normalization configuration to a batch of inputs.
+        """Applies the normalization configuration in-place to a batch of inputs.
+
+        `x` is changed in-place since the function is mainly used internally
+        to standarize images and feed them to your network. If a copy of `x`
+        would be created instead it would have a significant performance cost.
+        If you want to apply this method without changing the input in-place
+        you can call the method creating a copy before:
+
+        standarize(np.copy(x))
 
         # Arguments
             x: Batch of inputs to be normalized.


### PR DESCRIPTION
### Summary
At the moment the `standardize` method of `ImageDataGenerator` change the input inplace. This is a bad practice and should be avoided, as it is an unexpected behavior that faces the user and is unexpected. Since Keras puts the user first this should be avoided on any function facing the user directly. The behavior of course reduces the memory footprint and can bring benefits, but it should only be used on internal logic not on top-level user facing functions. 

This PR changes the behavior of the function to not change the user's input. It also adds tests to check that the input is not changed.

```
from keras.preprocessing.image import ImageDataGenerator

datagen = ImageDataGenerator(rescale=2)

images = np.ones((10, 128, 128, 3))
print(images.mean()) # 1.0

images_std = datagen.standardize(images)

print(images.mean(), images_std.mean()) # 2.0 2.0
```
### Related Issues
#85 

### PR Overview

- [y ] This PR requires new unit tests [y/n] (make sure tests are included)
- [n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
