### PR TITLE
Remove unused import

### DIFF
--- a/keras_preprocessing/image/dataframe_iterator.py
+++ b/keras_preprocessing/image/dataframe_iterator.py
@@ -11,7 +11,6 @@ from .iterator import Iterator
 from .utils import (array_to_img,
                     get_extension,
                     img_to_array,
-                    _list_valid_filenames_in_directory,
                     load_img)
 
 


### PR DESCRIPTION
### Summary
`_list_valid_filenames_in_directory` is unused.
### Related Issues

### PR Overview

- [n] This PR requires new unit tests [y/n] (make sure tests are included)
- [n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
