### PR TITLE
Improve performance of TimeSeriesGenerator by 1.7x-3x

### DIFF
--- a/keras_preprocessing/sequence.py
+++ b/keras_preprocessing/sequence.py
@@ -365,7 +365,8 @@ class TimeseriesGenerator(object):
             rows = np.arange(i, min(i + self.batch_size *
                                     self.stride, self.end_index + 1), self.stride)
 
-        samples = np.array([self.data[row - self.length:row:self.sampling_rate] for row in rows])
+        samples = np.array([self.data[row - self.length:row:self.sampling_rate] 
+                           for row in rows])
         targets = np.array([self.targets[row] for row in rows])
 
         if self.reverse:

--- a/keras_preprocessing/sequence.py
+++ b/keras_preprocessing/sequence.py
@@ -365,9 +365,9 @@ class TimeseriesGenerator(object):
             rows = np.arange(i, min(i + self.batch_size *
                                     self.stride, self.end_index + 1), self.stride)
 
-        samples = np.array([self.data[row-self.length:row:self.sampling_rate] for row in rows])
+        samples = np.array([self.data[row - self.length:row:self.sampling_rate] for row in rows])
         targets = np.array([self.targets[row] for row in rows])
-        
+
         if self.reverse:
             return samples[:, ::-1, ...], targets
         return samples, targets

--- a/keras_preprocessing/sequence.py
+++ b/keras_preprocessing/sequence.py
@@ -366,7 +366,7 @@ class TimeseriesGenerator(object):
                                     self.stride, self.end_index + 1), self.stride)
 
         samples = np.array([self.data[row - self.length:row:self.sampling_rate]
-                           for row in rows])
+                            for row in rows])
         targets = np.array([self.targets[row] for row in rows])
 
         if self.reverse:

--- a/keras_preprocessing/sequence.py
+++ b/keras_preprocessing/sequence.py
@@ -356,13 +356,6 @@ class TimeseriesGenerator(object):
         return (self.end_index - self.start_index +
                 self.batch_size * self.stride) // (self.batch_size * self.stride)
 
-    def _empty_batch(self, num_rows):
-        samples_shape = [num_rows, self.length // self.sampling_rate]
-        samples_shape.extend(self.data.shape[1:])
-        targets_shape = [num_rows]
-        targets_shape.extend(self.targets.shape[1:])
-        return np.empty(samples_shape), np.empty(targets_shape)
-
     def __getitem__(self, index):
         if self.shuffle:
             rows = np.random.randint(
@@ -372,11 +365,9 @@ class TimeseriesGenerator(object):
             rows = np.arange(i, min(i + self.batch_size *
                                     self.stride, self.end_index + 1), self.stride)
 
-        samples, targets = self._empty_batch(len(rows))
-        for j, row in enumerate(rows):
-            indices = range(rows[j] - self.length, rows[j], self.sampling_rate)
-            samples[j] = self.data[indices]
-            targets[j] = self.targets[rows[j]]
+        samples = np.array([self.data[row-self.length:row:self.sampling_rate] for row in rows])
+        targets = np.array([self.targets[row] for row in rows])
+        
         if self.reverse:
             return samples[:, ::-1, ...], targets
         return samples, targets

--- a/keras_preprocessing/sequence.py
+++ b/keras_preprocessing/sequence.py
@@ -365,7 +365,7 @@ class TimeseriesGenerator(object):
             rows = np.arange(i, min(i + self.batch_size *
                                     self.stride, self.end_index + 1), self.stride)
 
-        samples = np.array([self.data[row - self.length:row:self.sampling_rate] 
+        samples = np.array([self.data[row - self.length:row:self.sampling_rate]
                            for row in rows])
         targets = np.array([self.targets[row] for row in rows])
 


### PR DESCRIPTION
### Summary
Loads data and targets using a list comprehension which is much faster than a for loop & removes the need to pre-create an empty batch.

My own testing shows speedups of 1.7x-6x across all batch sizes (I've tested 4, 16, 64 and 256), multiple input/target dimensions (I've tested 1, 32 and 256 dimensional inputs & targets) and while loading the data from both disk and memory.

### Related Issues
None
### PR Overview

- [n] This PR requires new unit tests [y/n] (make sure tests are included)
- [n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
