### PR TITLE
Add pandas dependency in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(name='Keras_Preprocessing',
                    'keras-preprocessing/tarball/1.0.6',
       license='MIT',
       install_requires=['numpy>=1.9.1',
+                        'pandas>=0.18',
                         'six>=1.9.0'],
       extras_require={
           'tests': ['pytest',


### PR DESCRIPTION
### Summary
Import fails when pandas is not already installed. Specify it as a dependency in setup.py

### Related Issues
https://github.com/keras-team/keras-preprocessing/issues/154

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
