### PR TITLE
Remove unused pandas import

### DIFF
--- a/keras_preprocessing/image/dataframe_iterator.py
+++ b/keras_preprocessing/image/dataframe_iterator.py
@@ -8,7 +8,6 @@ import os
 import warnings
 
 import numpy as np
-from pandas.api.types import is_numeric_dtype
 
 from .iterator import BatchFromFilesMixin, Iterator
 from .utils import (array_to_img,


### PR DESCRIPTION
### Summary

At the moment there is an unused pandas import. This is also the only import of pandas in the source code which makes the import of the package break if the user hasn't pandas installed. This PR removes the import.

### Related Issues

#154 

### PR Overview

- [n ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [ y] This PR is backwards compatible [y/n]
- [ n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
