### PR TITLE
[WIP] Update CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,20 +3,30 @@ dist: trusty
 language: python
 matrix:
     include:
+        # check code style and Python 2.7
         - python: 2.7
           env: TEST_MODE=PEP8
+        # run tests with keras from source and Python 2.7
         - python: 2.7
           env: KERAS_HEAD=true
+          env: TEST_MODE=TESTS
+        # run tests with keras from source and Python 3.6
         - python: 3.6
           env: KERAS_HEAD=true
+          env: TEST_MODE=TESTS
+        # run tests with keras from PyPI and Python 2.7
         - python: 2.7
+          env: TEST_MODE=TESTS
+        # run tests with keras from PyPI and Python 3.6
         - python: 3.6
-install:
-  # code below is taken from http://conda.pydata.org/docs/travis.html
+          env: TEST_MODE=TESTS
+
+before_install:
+  - sudo apt-get update
   # We do this conditionally because it saves us some downloading if the
   # version is the same.
   - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
-      wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
+      wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;
     else
       wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
     fi
@@ -27,32 +37,24 @@ install:
   - conda update -q conda
   # Useful for debugging any issues with conda
   - conda info -a
-
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION pytest pandas
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
   - source activate test-environment
-  - pip install --only-binary=numpy,scipy numpy nose scipy keras
 
-  # set library path
-  - export LD_LIBRARY_PATH=$HOME/miniconda/envs/test-environment/lib/:$LD_LIBRARY_PATH
-
-  # install PIL for image tests
-  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
-      conda install pil;
-    elif [[ "$TRAVIS_PYTHON_VERSION" == "3.6" ]]; then
-      conda install Pillow;
-    fi
+install:
   - if [[ $KERAS_HEAD == "true" ]]; then
-      pip install --no-deps git+https://github.com/keras-team/keras.git ;
+      pip install --no-deps git+https://github.com/keras-team/keras.git --upgrade;
     fi
-  - pip install -e .[tests]
+  - if [[ "$TEST_MODE" == "PEP8" ]]; then
+      pip install -e .[pep8]
+    elif [[ "$TEST_MODE" == "TESTS" ]]; then
+      pip install -e .[tests]
+    fi
 
-  # install TensorFlow (CPU version).
-  - pip install tensorflow==1.7
-
-# command to run tests
 script:
   - if [[ "$TEST_MODE" == "PEP8" ]]; then
-      PYTHONPATH=$PWD:$PYTHONPATH py.test --pep8 -m pep8 -n0;
-    else
-      PYTHONPATH=$PWD:$PYTHONPATH py.test tests/ --cov-config .coveragerc --cov=keras_preprocessing tests/;
+      flake8 --count;
+    elif [[ "$TEST_MODE" == "TESTS" ]]; then
+      py.test --cov-config .coveragerc \
+              --cov=keras_preprocessing \
+              tests;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,13 @@ matrix:
         # run tests with keras from PyPI and Python 3.6
         - python: 3.6
           env: TEST_MODE=TESTS
+        # run import test and Python 2.7
+        - python: 2.7
+          env: TEST_MODE=IMPORTS
+        # run import test and Python 3.6
+        - python: 3.6
+          env: TEST_MODE=IMPORTS
+
 
 before_install:
   - sudo apt-get update
@@ -48,6 +55,8 @@ install:
       pip install -e .[pep8]
     elif [[ "$TEST_MODE" == "TESTS" ]]; then
       pip install -e .[tests]
+    elif [[ "$TEST_MODE" == "IMPORTS" ]]; then
+      pip install .
     fi
 
 script:
@@ -57,4 +66,9 @@ script:
       py.test --cov-config .coveragerc \
               --cov=keras_preprocessing \
               tests;
+    elif [[ "$TEST_MODE" == "IMPORTS" ]]; then
+      python -c "import keras_preprocessing; \
+      from keras_preprocessing import image; \
+      from keras_preprocessing import sequence; \
+      from keras_preprocessing import text";
     fi

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,18 +1,14 @@
 # Configuration of py.test
-[pytest]
-addopts=-v
-        -n 2
-        --durations=20
-
+[tool:pytest]]
+addopts = -v -n 2 --durations=20
 # Do not run tests in the build folder
-norecursedirs= build
+norecursedirs = build
 
+[flake8]
 # Use 85 as max line length in PEP8 test.
-pep8maxlinelength=85
-
+max-line-length=85
 # PEP-8 The following are ignored:
 # E731 do not assign a lambda expression, use a def
 # E402 module level import not at top of file
-
 pep8ignore=* E731 \
            * E402 \

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+import sys
+
 from setuptools import setup
 from setuptools import find_packages
 
@@ -33,10 +35,14 @@ setup(name='Keras_Preprocessing',
       install_requires=['numpy>=1.9.1',
                         'six>=1.9.0'],
       extras_require={
-          'tests': ['pytest',
-                    'pytest-pep8',
+          'tests': ['pandas',
+                    'Pillow' if sys.version_info > (3, 0) else 'pil',
+                    'tensorflow==1.7',  # CPU version
+                    'keras',
+                    'pytest',
                     'pytest-xdist',
                     'pytest-cov'],
+          'pep8': ['flake8'],
           'image': ['scipy>=0.14',
                     'Pillow>=5.2.0'],
       },


### PR DESCRIPTION
### Summary
Update CI, basically separate every test component.
- PEP8 (no dependencies installed at all)
- PyTests (install test dependencies), runs for Python 2.6, 3.6 and Keras PyPI and Keras HEAD
- Imports (install package dependencies), runs for Python 2.6, 3.6. Basically imports the package and modules as a check that nothing breaks.

I also change where some of the logic happens. Before there was some logic in `travis.yml` that in my opinion `shuoldn't` be there but in `setup.py`, in this way the user can actually execute the same that travis is doing by `pip install -e .[tests] && pytest tests` or  `pip install -e .[pep8] && flake8`. So much easier to debug without the need to push and create a pull request to reproduce travis execution (up to some complexity).

This should lead to a more robust check and specially avoid the error given during the release of 1.0.6. That error for example will be catch in two places now: 
- PEP8: as an unused import
- Imports: since pandas is not installed on that check.

NOTE: The phase caching the bug in the 1.0.6 should not be the Pytest phase, that actually should work. Since pandas is needed for unit testing.

### Related Issues
#154 

### PR Overview

- [ n] This PR requires new unit tests [y/n] (make sure tests are included)
- [ n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [ y] This PR is backwards compatible [y/n]
- [ n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)