### PR TITLE
Custom split functions for text_to_word_sequence

### DIFF
--- a/keras_preprocessing/text.py
+++ b/keras_preprocessing/text.py
@@ -34,7 +34,8 @@ def text_to_word_sequence(text,
             punctuation. Default: ``!"#$%&()*+,-./:;<=>?@[\\]^_`{|}~\\t\\n``,
             includes basic punctuation, tabs, and newlines.
         lower: boolean. Whether to convert the input to lowercase.
-        split: str. Separator for word splitting.
+        split: Either a string separator or a function that accepts a string
+            and returns sequence of strings which have been split.
 
     # Returns
         A list of words (or tokens).
@@ -57,7 +58,14 @@ def text_to_word_sequence(text,
         translate_map = maketrans(translate_dict)
         text = text.translate(translate_map)
 
-    seq = text.split(split)
+    if callable(split):
+        seq = split(text)
+    elif isinstance(split, str):
+        seq = text.split(split)
+    else:
+        raise TypeError('''`split` should either be a string or a function.
+                    Found a {}'''.format(type(split)))
+
     return [i for i in seq if i]
 
 
@@ -77,7 +85,8 @@ def one_hot(text, n,
             punctuation. Default: ``!"#$%&()*+,-./:;<=>?@[\\]^_`{|}~\\t\\n``,
             includes basic punctuation, tabs, and newlines.
         lower: boolean. Whether to set the text to lowercase.
-        split: str. Separator for word splitting.
+        split: Either a separator string or a function that accepts a string
+            and returns sequence of strings which have been split.
 
     # Returns
         List of integers in [1, n]. Each integer encodes a word
@@ -109,7 +118,8 @@ def hashing_trick(text, n,
             punctuation. Default: ``!"#$%&()*+,-./:;<=>?@[\\]^_`{|}~\\t\\n``,
             includes basic punctuation, tabs, and newlines.
         lower: boolean. Whether to set the text to lowercase.
-        split: str. Separator for word splitting.
+        split: Either a separator string or a function that accepts a string
+            and returns sequence of strings which have been split.
 
     # Returns
         A list of integer word indices (unicity non-guaranteed).
@@ -152,7 +162,8 @@ class Tokenizer(object):
             filtered from the texts. The default is all punctuation, plus
             tabs and line breaks, minus the `'` character.
         lower: boolean. Whether to convert the texts to lowercase.
-        split: str. Separator for word splitting.
+        split: Either a separator string or a function that accepts a string
+            and returns sequence of strings which have been split.
         char_level: if True, every character will be treated as a token.
         oov_token: if given, it will be added to word_index and used to
             replace out-of-vocabulary words during text_to_sequence calls

--- a/keras_preprocessing/text.py
+++ b/keras_preprocessing/text.py
@@ -43,25 +43,27 @@ def text_to_word_sequence(text,
     if lower:
         text = text.lower()
 
-    if sys.version_info < (3,):
-        if isinstance(text, unicode):
-            translate_map = dict((ord(c), unicode(split)) for c in filters)
-            text = text.translate(translate_map)
-        elif len(split) == 1:
-            translate_map = maketrans(filters, split * len(filters))
-            text = text.translate(translate_map)
-        else:
-            for c in filters:
-                text = text.replace(c, split)
-    else:
-        translate_dict = dict((c, split) for c in filters)
-        translate_map = maketrans(translate_dict)
-        text = text.translate(translate_map)
-
     if callable(split):
+        if filters not in {None, ''}:
+            warnings.warn("""The `filters` argument is ignored if `split`
+                argument is a function""")
         seq = split(text)
     elif isinstance(split, str):
-        seq = text.split(split)
+        if sys.version_info < (3,):
+            if isinstance(text, unicode):
+                translate_map = dict((ord(c), unicode(split)) for c in filters)
+                text = text.translate(translate_map)
+            elif len(split) == 1:
+                translate_map = maketrans(filters, split * len(filters))
+                text = text.translate(translate_map)
+            else:
+                for c in filters:
+                    text = text.replace(c, split)
+        else:
+            translate_dict = dict((c, split) for c in filters)
+            translate_map = maketrans(translate_dict)
+            text = text.translate(translate_map)
+            seq = text.split(split)
     else:
         raise TypeError('''`split` should either be a string or a function.
                     Found a {}'''.format(type(split)))

--- a/tests/text_test.py
+++ b/tests/text_test.py
@@ -118,6 +118,16 @@ def test_text_to_word_sequence():
     assert text.text_to_word_sequence(sample_text) == ['hello', 'world']
 
 
+def test_text_to_word_sequence_split_function():
+    sample_text = "How're you"
+
+    def custom_split(text):
+        text = text.replace("'", " '")
+        return text.split()
+
+    assert text.text_to_word_sequence(sample_text, split=custom_split) == ['how', "'re", "you"]
+
+
 def test_text_to_word_sequence_multichar_split():
     sample_text = 'hello!stop?world!'
     assert text.text_to_word_sequence(

--- a/tests/text_test.py
+++ b/tests/text_test.py
@@ -125,7 +125,8 @@ def test_text_to_word_sequence_split_function():
         text = text.replace("'", " '")
         return text.split()
 
-    assert text.text_to_word_sequence(sample_text, split=custom_split) == ['how', "'re", "you"]
+    assert text.text_to_word_sequence(
+        sample_text, split=custom_split) == ['how', "'re", "you"]
 
 
 def test_text_to_word_sequence_multichar_split():


### PR DESCRIPTION
### Summary
Allow users to pass a function into `split` argument to implement custom splitting

### Related Issues

### PR Overview

- [x] This PR requires new unit tests [y/n] (make sure tests are included)
- [x] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [x] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
