### PR TITLE
Add sample weights to DataFrameIterator

### DIFF
--- a/keras_preprocessing/image/dataframe_iterator.py
+++ b/keras_preprocessing/image/dataframe_iterator.py
@@ -169,8 +169,8 @@ class DataFrameIterator(BatchFromFilesMixin, Iterator):
                              .format(self.class_mode, self.allowed_class_modes))
         # check that filenames/filepaths column values are all strings
         if not all(df[x_col].apply(lambda x: isinstance(x, str))):
-            raise ValueError('All values in column x_col={} must be strings.'
-                             .format(x_col))
+            raise TypeError('All values in column x_col={} must be strings.'
+                            .format(x_col))
         # check labels are string if class_mode is binary or sparse
         if self.class_mode in {'binary', 'sparse'}:
             if not all(df[y_col].apply(lambda x: isinstance(x, str))):
@@ -201,8 +201,8 @@ class DataFrameIterator(BatchFromFilesMixin, Iterator):
                           .format(self.class_mode))
         # check that if weight column that the values are numerical
         if weight_col and not issubclass(df[weight_col].dtype.type, np.number):
-            raise ValueError('Column weight_col={} must be numeric.'
-                             .format(weight_col))
+            raise TypeError('Column weight_col={} must be numeric.'
+                            .format(weight_col))
 
     def get_classes(self, df, y_col):
         labels = []

--- a/keras_preprocessing/image/dataframe_iterator.py
+++ b/keras_preprocessing/image/dataframe_iterator.py
@@ -271,8 +271,6 @@ class DataFrameIterator(BatchFromFilesMixin, Iterator):
     def sample_weight(self):
         if hasattr(self, '_sample_weight'):
             return self._sample_weight
-        else:
-            return None
 
     @property
     def data(self):

--- a/keras_preprocessing/image/dataframe_iterator.py
+++ b/keras_preprocessing/image/dataframe_iterator.py
@@ -7,6 +7,8 @@ from __future__ import print_function
 import os
 import warnings
 
+import numpy as np
+
 from .iterator import BatchFromFilesMixin, Iterator
 from .utils import get_extension
 
@@ -37,6 +39,8 @@ class DataFrameIterator(BatchFromFilesMixin, Iterator):
         x_col: string, column in `dataframe` that contains the filenames (or
             absolute paths if `directory` is `None`).
         y_col: string or list, column/s in `dataframe` that has the target data.
+        weight_col: string, column in `dataframe` that contains the sample
+            wights. Default: `None`.
         target_size: tuple of integers, dimensions to resize input images to.
         color_mode: One of `"rgb"`, `"rgba"`, `"grayscale"`.
             Color mode to read images.
@@ -87,6 +91,7 @@ class DataFrameIterator(BatchFromFilesMixin, Iterator):
                  image_data_generator=None,
                  x_col="filename",
                  y_col="class",
+                 weight_col=None,
                  target_size=(256, 256),
                  color_mode='rgb',
                  classes=None,
@@ -117,7 +122,7 @@ class DataFrameIterator(BatchFromFilesMixin, Iterator):
         self.class_mode = class_mode
         self.dtype = dtype
         # check that inputs match the required class_mode
-        self._check_params(df, x_col, y_col, classes)
+        self._check_params(df, x_col, y_col, weight_col, classes)
         if drop_duplicates:
             df.drop_duplicates(x_col, inplace=True)
         # check which image files are valid and keep them
@@ -155,7 +160,7 @@ class DataFrameIterator(BatchFromFilesMixin, Iterator):
                                                 shuffle,
                                                 seed)
 
-    def _check_params(self, df, x_col, y_col, classes):
+    def _check_params(self, df, x_col, y_col, weight_col, classes):
         # check class mode is one of the currently supported
         if self.class_mode not in self.allowed_class_modes:
             raise ValueError('Invalid class_mode: {}; expected one of: {}'
@@ -192,6 +197,12 @@ class DataFrameIterator(BatchFromFilesMixin, Iterator):
         if classes and self.class_mode in {"other", "input", None}:
             warnings.warn('`classes` will be ignored given the class_mode="{}"'
                           .format(self.class_mode))
+        # check that if weight column that the values are numerical
+        if (weight_col and
+            issubclass(df[weight_col].dtype, np.number) and not
+                issubclass(df[weight_col].dtype, (np.datetime64, np.timedelta64))):
+            raise ValueError('Column weight_col={} must be numeric.'
+                             .format(weight_col))
 
     def get_classes(self, df, y_col):
         labels = []

--- a/keras_preprocessing/image/dataframe_iterator.py
+++ b/keras_preprocessing/image/dataframe_iterator.py
@@ -142,6 +142,8 @@ class DataFrameIterator(BatchFromFilesMixin, Iterator):
         if class_mode not in ["other", "input", None]:
             self.classes = self.get_classes(df, y_col)
         self.filenames = df[x_col].tolist()
+        if weight_col:
+            self._sample_weight = df[weight_col].values
         # create numpy array of raw input if class_mode="other"
         if class_mode == "other":
             self._data = df[y_col].values
@@ -266,6 +268,13 @@ class DataFrameIterator(BatchFromFilesMixin, Iterator):
     @property
     def labels(self):
         return self.classes
+
+    @property
+    def sample_weight(self):
+        if hasattr(self, '_sample_weight'):
+            return self._sample_weight
+        else:
+            return None
 
     @property
     def data(self):

--- a/keras_preprocessing/image/dataframe_iterator.py
+++ b/keras_preprocessing/image/dataframe_iterator.py
@@ -40,7 +40,7 @@ class DataFrameIterator(BatchFromFilesMixin, Iterator):
             absolute paths if `directory` is `None`).
         y_col: string or list, column/s in `dataframe` that has the target data.
         weight_col: string, column in `dataframe` that contains the sample
-            wights. Default: `None`.
+            weights. Default: `None`.
         target_size: tuple of integers, dimensions to resize input images to.
         color_mode: One of `"rgb"`, `"rgba"`, `"grayscale"`.
             Color mode to read images.
@@ -200,9 +200,7 @@ class DataFrameIterator(BatchFromFilesMixin, Iterator):
             warnings.warn('`classes` will be ignored given the class_mode="{}"'
                           .format(self.class_mode))
         # check that if weight column that the values are numerical
-        if (weight_col and
-            issubclass(df[weight_col].dtype, np.number) and not
-                issubclass(df[weight_col].dtype, (np.datetime64, np.timedelta64))):
+        if weight_col and not issubclass(df[weight_col].dtype.type, np.number):
             raise ValueError('Column weight_col={} must be numeric.'
                              .format(weight_col))
 

--- a/keras_preprocessing/image/dataframe_iterator.py
+++ b/keras_preprocessing/image/dataframe_iterator.py
@@ -142,8 +142,8 @@ class DataFrameIterator(BatchFromFilesMixin, Iterator):
         if class_mode not in ["other", "input", None]:
             self.classes = self.get_classes(df, y_col)
         self.filenames = df[x_col].tolist()
-        if weight_col:
-            self._sample_weight = df[weight_col].values
+        self._sample_weight = df[weight_col].values if weight_col else None
+
         # create numpy array of raw input if class_mode="other"
         if class_mode == "other":
             self._data = df[y_col].values
@@ -269,8 +269,7 @@ class DataFrameIterator(BatchFromFilesMixin, Iterator):
 
     @property
     def sample_weight(self):
-        if hasattr(self, '_sample_weight'):
-            return self._sample_weight
+        return self._sample_weight
 
     @property
     def data(self):

--- a/keras_preprocessing/image/directory_iterator.py
+++ b/keras_preprocessing/image/directory_iterator.py
@@ -147,3 +147,8 @@ class DirectoryIterator(BatchFromFilesMixin, Iterator):
     @property
     def labels(self):
         return self.classes
+
+    @property  # mixin needs this property to work
+    def sample_weight(self):
+        # no sample weights will be returned
+        return None

--- a/keras_preprocessing/image/image_data_generator.py
+++ b/keras_preprocessing/image/image_data_generator.py
@@ -543,6 +543,7 @@ class ImageDataGenerator(object):
                             directory=None,
                             x_col="filename",
                             y_col="class",
+                            weight_col=None,
                             target_size=(256, 256),
                             color_mode='rgb',
                             classes=None,
@@ -583,6 +584,8 @@ class ImageDataGenerator(object):
             x_col: string, column in `dataframe` that contains the filenames (or
                 absolute paths if `directory` is `None`).
             y_col: string or list, column/s in `dataframe` that has the target data.
+            weight_col: string, column in `dataframe` that contains the sample
+                weights. Default: `None`.
             target_size: tuple of integers `(height, width)`, default: `(256, 256)`.
                 The dimensions to which all images found will be resized.
             color_mode: one of "grayscale", "rgb". Default: "rgb".
@@ -650,6 +653,7 @@ class ImageDataGenerator(object):
             self,
             x_col=x_col,
             y_col=y_col,
+            weight_col=weight_col,
             target_size=target_size,
             color_mode=color_mode,
             classes=classes,

--- a/keras_preprocessing/image/iterator.py
+++ b/keras_preprocessing/image/iterator.py
@@ -260,7 +260,10 @@ class BatchFromFilesMixin():
             batch_y = self.data[index_array]
         else:
             return batch_x
-        return batch_x, batch_y
+        if self.sample_weight is None:
+            return batch_x, batch_y
+        else:
+            return batch_x, batch_y, self.sample_weight[index_array]
 
     @property
     def filepaths(self):
@@ -275,6 +278,13 @@ class BatchFromFilesMixin():
         """Class labels of every observation"""
         raise NotImplementedError(
             '`labels` property method has not been implemented in {}.'
+            .format(type(self).__name__)
+        )
+
+    @property
+    def sample_weight(self):
+        raise NotImplementedError(
+            '`sample_weight` property method has not been implemented in {}.'
             .format(type(self).__name__)
         )
 

--- a/tests/image_test.py
+++ b/tests/image_test.py
@@ -622,6 +622,13 @@ class TestImage(object):
         assert input_img[0][0][0] != output_img[0][0][0]
         assert np.array_equal(np.array([2, 5, 2, 5, 2]), batch[2])
 
+        # fail
+        df['weight'] = (['2', '5'] * len(df))[:len(df)]
+        with pytest.raises(TypeError):
+            image.ImageDataGenerator().flow_from_dataframe(df,
+                                                           weight_col='weight',
+                                                           class_mode="input")
+
     def test_dataframe_iterator_class_mode_input(self, tmpdir):
         # save the images in the paths
         count = 0


### PR DESCRIPTION
### Summary
Currently there is no implementation of sample weights in DataFrameIterator or flow_from_dataframe. This PR adds that functionality. 
For example with this PR is now possible to train a model using sample weights, given that a column of weights is added to the pandas dataframe.
```
generator = ImageDataGenerator().flow_from_dataframe(
    df,
    weight_col='weights'
)
model.fit_generator(generator, epochs=2, steps_per_epoch=10)
```
### Related Issues
Solves #147 

### PR Overview

- [y ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ y] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [ y] This PR is backwards compatible [y/n]
- [ n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
