### PR TITLE
Add numbers and - to image names found by list_pictures.

### DIFF
--- a/keras_preprocessing/image/utils.py
+++ b/keras_preprocessing/image/utils.py
@@ -137,7 +137,7 @@ def list_pictures(directory, ext=('jpg', 'jpeg', 'bmp', 'png', 'ppm')):
         a list of paths
     """
     if not isinstance(ext, tuple):
-        ext = tuple(ext)
+        ext = (ext,)
     ext = tuple('.%s' % e for e in ext)
     return [os.path.join(root, f)
             for root, _, files in os.walk(directory) for f in files

--- a/keras_preprocessing/image/utils.py
+++ b/keras_preprocessing/image/utils.py
@@ -5,7 +5,6 @@ from __future__ import division
 from __future__ import print_function
 
 import os
-import re
 import warnings
 
 import numpy as np

--- a/keras_preprocessing/image/utils.py
+++ b/keras_preprocessing/image/utils.py
@@ -138,7 +138,7 @@ def list_pictures(directory, ext=('jpg', 'jpeg', 'bmp', 'png', 'ppm')):
     """
     if not isinstance(ext, tuple):
         ext = tuple(ext)
-    ext = tuple(f'.{e}' for e in ext)
+    ext = tuple('.%s' % e for e in ext)
     return [os.path.join(root, f)
             for root, _, files in os.walk(directory) for f in files
             if f.lower().endswith(ext)]

--- a/keras_preprocessing/image/utils.py
+++ b/keras_preprocessing/image/utils.py
@@ -130,7 +130,7 @@ def load_img(path, grayscale=False, color_mode='rgb', target_size=None,
 def list_pictures(directory, ext='jpg|jpeg|bmp|png|ppm'):
     return [os.path.join(root, f)
             for root, _, files in os.walk(directory) for f in files
-            if re.match(r'([\w]+\.(?:' + ext + '))', f.lower())]
+            if re.match(r'([\w\d-]+\.(?:' + ext + '))', f.lower())]
 
 
 def _iter_valid_files(directory, white_list_formats, follow_links):

--- a/keras_preprocessing/image/utils.py
+++ b/keras_preprocessing/image/utils.py
@@ -127,18 +127,21 @@ def load_img(path, grayscale=False, color_mode='rgb', target_size=None,
     return img
 
 
-def list_pictures(directory, ext='jpg|jpeg|bmp|png|ppm'):
+def list_pictures(directory, ext=('jpg', 'jpeg', 'bmp', 'png', 'ppm')):
     """Lists all pictures in a directory, including all subdirectories.
 
     # Arguments
-        directory: Absolute path to the directory
-        ext: extensions of the pictures, separated by '|'
+        directory: string, absolute path to the directory
+        ext: tuple of strings, extensions of the pictures, separated by '|'
     # Returns
         a list of paths
     """
+    if not isinstance(ext, tuple):
+        ext = tuple(ext)
+    ext = tuple(f'.{e}' for e in ext)
     return [os.path.join(root, f)
             for root, _, files in os.walk(directory) for f in files
-            if re.match(r'.*(' + ext + ')$', f.lower())]
+            if f.lower().endswith(ext)]
 
 
 def _iter_valid_files(directory, white_list_formats, follow_links):

--- a/keras_preprocessing/image/utils.py
+++ b/keras_preprocessing/image/utils.py
@@ -127,7 +127,8 @@ def load_img(path, grayscale=False, color_mode='rgb', target_size=None,
     return img
 
 
-def list_pictures(directory, ext=('jpg', 'jpeg', 'bmp', 'png', 'ppm')):
+def list_pictures(directory, ext=('jpg', 'jpeg', 'bmp', 'png', 'ppm', 'tif',
+                                  'tiff')):
     """Lists all pictures in a directory, including all subdirectories.
 
     # Arguments

--- a/keras_preprocessing/image/utils.py
+++ b/keras_preprocessing/image/utils.py
@@ -132,13 +132,11 @@ def list_pictures(directory, ext=('jpg', 'jpeg', 'bmp', 'png', 'ppm')):
 
     # Arguments
         directory: string, absolute path to the directory
-        ext: tuple of strings, extensions of the pictures, separated by '|'
+        ext: tuple of strings or single string, extensions of the pictures
     # Returns
         a list of paths
     """
-    if not isinstance(ext, tuple):
-        ext = (ext,)
-    ext = tuple('.%s' % e for e in ext)
+    ext = tuple('.%s' % e for e in ((ext,) if isinstance(ext, str) else ext))
     return [os.path.join(root, f)
             for root, _, files in os.walk(directory) for f in files
             if f.lower().endswith(ext)]

--- a/keras_preprocessing/image/utils.py
+++ b/keras_preprocessing/image/utils.py
@@ -128,9 +128,17 @@ def load_img(path, grayscale=False, color_mode='rgb', target_size=None,
 
 
 def list_pictures(directory, ext='jpg|jpeg|bmp|png|ppm'):
+    """Lists all pictures in a directory, including all subdirectories.
+
+    # Arguments
+        directory: Absolute path to the directory
+        ext: extensions of the pictures, separated by '|'
+    # Returns
+        a list of paths
+    """
     return [os.path.join(root, f)
             for root, _, files in os.walk(directory) for f in files
-            if re.match(r'([\w\d-]+\.(?:' + ext + '))', f.lower())]
+            if re.match(r'.*(' + ext + ')$', f.lower())]
 
 
 def _iter_valid_files(directory, white_list_formats, follow_links):

--- a/tests/image_test.py
+++ b/tests/image_test.py
@@ -1232,7 +1232,7 @@ class TestImage(object):
         filenames = ['test.png', 'test0.jpg', 'test-1.jpeg', '2test.bmp',
                      '2-test.ppm', '3.png', '1.jpeg', 'test.bmp', 'test0.ppm']
         subdirs = ['', 'subdir1', 'subdir2']
-        images = [os.path.join(tmpdir, subdir, f) for subdir in subdirs
+        images = [tmpdir.mkdir(subdir).join(f) for subdir in subdirs
                   for f in filenames]
 
         for img in images:

--- a/tests/image_test.py
+++ b/tests/image_test.py
@@ -6,6 +6,7 @@ import tempfile
 import shutil
 import pandas as pd
 import random
+import string
 
 from keras_preprocessing import image
 
@@ -1224,6 +1225,21 @@ class TestImage(object):
             loaded_im = image.load_img(filename_rgb, target_size=(25, 25),
                                        interpolation="unsupported")
 
+
+    def test_list_pictures(self, tmpdir):
+        vocab = list(string.ascii_lowercase + string.ascii_uppercase +
+                     string.digits + '-')
+        images = []
+
+        for i in range(100):
+            images.append(os.path.join(tmpdir,
+                                       f'{"".join(np.random.choice(vocab,
+                                                                   10))}.png'))
+            image.array_to_img(np.array(255 * np.random.rand(100, 100, 3),
+                               dtype=np.uint8), scale=False).save(images[-1])
+
+        found_images = image.list_pictures(tmpdir)
+        assert len(found_images) == len(images)
 
 if __name__ == '__main__':
     pytest.main([__file__])

--- a/tests/image_test.py
+++ b/tests/image_test.py
@@ -1227,16 +1227,15 @@ class TestImage(object):
 
 
     def test_list_pictures(self, tmpdir):
-        vocab = list(string.ascii_lowercase + string.ascii_uppercase +
-                     string.digits + '-')
-        images = []
+        images.append(os.path.join(tmpdir, 'test.png'))
+        images.append(os.path.join(tmpdir, 'test0.jpg'))
+        images.append(os.path.join(tmpdir, 'test-1.jpeg'))
+        images.append(os.path.join(tmpdir, '2test.bmp'))
+        images.append(os.path.join(tmpdir, '2-test.ppm'))
+        images.append(os.path.join(tmpdir, '3.png'))
 
-        for i in range(100):
-            images.append(os.path.join(tmpdir,
-                                       f'{"".join(np.random.choice(vocab,
-                                                                   10))}.png'))
-            image.array_to_img(np.array(255 * np.random.rand(100, 100, 3),
-                               dtype=np.uint8), scale=False).save(images[-1])
+        for img in images:
+            Image.new('RGB', (32, 32)).save(img)
 
         found_images = image.list_pictures(tmpdir)
         assert len(found_images) == len(images)

--- a/tests/image_test.py
+++ b/tests/image_test.py
@@ -6,7 +6,6 @@ import tempfile
 import shutil
 import pandas as pd
 import random
-import string
 
 from keras_preprocessing import image
 

--- a/tests/image_test.py
+++ b/tests/image_test.py
@@ -1225,20 +1225,15 @@ class TestImage(object):
             loaded_im = image.load_img(filename_rgb, target_size=(25, 25),
                                        interpolation="unsupported")
 
-
     def test_list_pictures(self, tmpdir):
         os.mkdir(os.path.join(tmpdir, 'class1'))
         os.mkdir(os.path.join(tmpdir, 'class2'))
 
         filenames = ['test.png', 'test0.jpg', 'test-1.jpeg', '2test.bmp',
-                     '2-test.ppm', '3.png']
-        images = [os.path.join(tmpdir, f) for f in filenames]
-
-        class1 = ['test.png', 'test0.jpg', '1.jpeg']
-        images += [os.path.join(tmpdir, 'class1', f) for f in class1]
-
-        class2 = ['test.bmp', 'test0.ppm', '1.jpeg']
-        images += [os.path.join(tmpdir, 'class2', f) for f in class2]
+                     '2-test.ppm', '3.png', '1.jpeg', 'test.bmp', 'test0.ppm']
+        subdirs = ['', 'subdir1', 'subdir2']
+        images = [os.path.join(tmpdir, subdir, f) for subdir in subdirs
+                  for f in filenames]
 
         for img in images:
             with open(img, 'w') as f:
@@ -1249,6 +1244,7 @@ class TestImage(object):
 
         found_images = image.list_pictures(tmpdir, ext='png')
         assert len(found_images) == 3
+
 
 if __name__ == '__main__':
     pytest.main([__file__])

--- a/tests/image_test.py
+++ b/tests/image_test.py
@@ -1227,19 +1227,17 @@ class TestImage(object):
 
     def test_list_pictures(self, tmpdir):
         filenames = ['test.png', 'test0.jpg', 'test-1.jpeg', '2test.bmp',
-                     '2-test.ppm', '3.png', '1.jpeg', 'test.bmp', 'test0.ppm']
+                     '2-test.ppm', '3.png', '1.jpeg', 'test.bmp', 'test0.ppm',
+                     'test4.tiff', '5-test.tif', 'test.txt', 'foo.csv',
+                     'face.gif', 'bar.txt']
         subdirs = ['', 'subdir1', 'subdir2']
-        images = [tmpdir.ensure(subdir, dir=True).join(f) for subdir in subdirs
+        images = [tmpdir.ensure(subdir, f) for subdir in subdirs
                   for f in filenames]
 
-        for img in images:
-            with open(str(img), 'w') as f:
-                f.write('\n')
+        found_images = image.list_pictures(str(tmpdir))
+        assert len(found_images) == 33
 
-        found_images = image.list_pictures(tmpdir)
-        assert len(found_images) == len(images)
-
-        found_images = image.list_pictures(tmpdir, ext='png')
+        found_images = image.list_pictures(str(tmpdir), ext='png')
         assert len(found_images) == 6
 
 

--- a/tests/image_test.py
+++ b/tests/image_test.py
@@ -1229,8 +1229,8 @@ class TestImage(object):
         filenames = ['test.png', 'test0.jpg', 'test-1.jpeg', '2test.bmp',
                      '2-test.ppm', '3.png', '1.jpeg', 'test.bmp', 'test0.ppm']
         subdirs = ['', 'subdir1', 'subdir2']
-        images = [tmpdir.makedirs(subdir, exist_ok=True).join(f)
-                  for subdir in subdirs for f in filenames]
+        images = [tmpdir.ensure(subdir, dir=True).join(f) for subdir in subdirs
+                  for f in filenames]
 
         for img in images:
             with open(img, 'w') as f:
@@ -1240,7 +1240,7 @@ class TestImage(object):
         assert len(found_images) == len(images)
 
         found_images = image.list_pictures(tmpdir, ext='png')
-        assert len(found_images) == 3
+        assert len(found_images) == 6
 
 
 if __name__ == '__main__':

--- a/tests/image_test.py
+++ b/tests/image_test.py
@@ -1234,8 +1234,18 @@ class TestImage(object):
         images.append(os.path.join(tmpdir, '2-test.ppm'))
         images.append(os.path.join(tmpdir, '3.png'))
 
+        os.mkdir(os.path.join(tmpdir, 'class1'))
+        images.append(os.path.join(tmpdir, 'class1', 'test.png'))
+        images.append(os.path.join(tmpdir, 'class1', 'test0.jpg'))
+        images.append(os.path.join(tmpdir, 'class1', '1.jpeg'))
+
+        os.mkdir(os.path.join(tmpdir, 'class2'))
+        images.append(os.path.join(tmpdir, 'class2', 'test.bmp'))
+        images.append(os.path.join(tmpdir, 'class2', 'test0.ppm'))
+        images.append(os.path.join(tmpdir, 'class2', '1.jpeg'))
+
         for img in images:
-            Image.new('RGB', (32, 32)).save(img)
+            os.mknod(img)
 
         found_images = image.list_pictures(tmpdir)
         assert len(found_images) == len(images)

--- a/tests/image_test.py
+++ b/tests/image_test.py
@@ -1227,28 +1227,28 @@ class TestImage(object):
 
 
     def test_list_pictures(self, tmpdir):
-        images = [os.path.join(tmpdir, 'test.png')]
-        images.append(os.path.join(tmpdir, 'test0.jpg'))
-        images.append(os.path.join(tmpdir, 'test-1.jpeg'))
-        images.append(os.path.join(tmpdir, '2test.bmp'))
-        images.append(os.path.join(tmpdir, '2-test.ppm'))
-        images.append(os.path.join(tmpdir, '3.png'))
-
         os.mkdir(os.path.join(tmpdir, 'class1'))
-        images.append(os.path.join(tmpdir, 'class1', 'test.png'))
-        images.append(os.path.join(tmpdir, 'class1', 'test0.jpg'))
-        images.append(os.path.join(tmpdir, 'class1', '1.jpeg'))
-
         os.mkdir(os.path.join(tmpdir, 'class2'))
-        images.append(os.path.join(tmpdir, 'class2', 'test.bmp'))
-        images.append(os.path.join(tmpdir, 'class2', 'test0.ppm'))
-        images.append(os.path.join(tmpdir, 'class2', '1.jpeg'))
+
+        filenames = ['test.png', 'test0.jpg', 'test-1.jpeg', '2test.bmp',
+                     '2-test.ppm', '3.png']
+        images = [os.path.join(tmpdir, f) for f in filenames]
+
+        class1 = ['test.png', 'test0.jpg', '1.jpeg']
+        images += [os.path.join(tmpdir, 'class1', f) for f in class1]
+
+        class2 = ['test.bmp', 'test0.ppm', '1.jpeg']
+        images += [os.path.join(tmpdir, 'class2', f) for f in class2]
 
         for img in images:
-            os.mknod(img)
+            with open(img, 'w') as f:
+                f.write('\n')
 
         found_images = image.list_pictures(tmpdir)
         assert len(found_images) == len(images)
+
+        found_images = image.list_pictures(tmpdir, ext='png')
+        assert len(found_images) == 3
 
 if __name__ == '__main__':
     pytest.main([__file__])

--- a/tests/image_test.py
+++ b/tests/image_test.py
@@ -1231,8 +1231,8 @@ class TestImage(object):
                      'test4.tiff', '5-test.tif', 'test.txt', 'foo.csv',
                      'face.gif', 'bar.txt']
         subdirs = ['', 'subdir1', 'subdir2']
-        images = [tmpdir.ensure(subdir, f) for subdir in subdirs
-                  for f in filenames]
+        filenames = [tmpdir.ensure(subdir, f) for subdir in subdirs
+                     for f in filenames]
 
         found_images = image.list_pictures(str(tmpdir))
         assert len(found_images) == 33

--- a/tests/image_test.py
+++ b/tests/image_test.py
@@ -1233,7 +1233,7 @@ class TestImage(object):
                   for f in filenames]
 
         for img in images:
-            with open(img, 'w') as f:
+            with open(str(img), 'w') as f:
                 f.write('\n')
 
         found_images = image.list_pictures(tmpdir)

--- a/tests/image_test.py
+++ b/tests/image_test.py
@@ -1226,14 +1226,11 @@ class TestImage(object):
                                        interpolation="unsupported")
 
     def test_list_pictures(self, tmpdir):
-        os.mkdir(os.path.join(tmpdir, 'class1'))
-        os.mkdir(os.path.join(tmpdir, 'class2'))
-
         filenames = ['test.png', 'test0.jpg', 'test-1.jpeg', '2test.bmp',
                      '2-test.ppm', '3.png', '1.jpeg', 'test.bmp', 'test0.ppm']
         subdirs = ['', 'subdir1', 'subdir2']
-        images = [tmpdir.mkdir(subdir).join(f) for subdir in subdirs
-                  for f in filenames]
+        images = [tmpdir.makedirs(subdir, exist_ok=True).join(f)
+                  for subdir in subdirs for f in filenames]
 
         for img in images:
             with open(img, 'w') as f:

--- a/tests/image_test.py
+++ b/tests/image_test.py
@@ -1227,7 +1227,7 @@ class TestImage(object):
 
 
     def test_list_pictures(self, tmpdir):
-        images.append(os.path.join(tmpdir, 'test.png'))
+        images = [os.path.join(tmpdir, 'test.png')]
         images.append(os.path.join(tmpdir, 'test0.jpg'))
         images.append(os.path.join(tmpdir, 'test-1.jpeg'))
         images.append(os.path.join(tmpdir, '2test.bmp'))


### PR DESCRIPTION
### Summary
Currently list_pictures  only finds images with letters expanding this to include numbers and -.
### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [ ] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
