### PR TITLE
Add multi-output support to `flow_from_dataframe`

### DIFF
--- a/keras_preprocessing/image/dataframe_iterator.py
+++ b/keras_preprocessing/image/dataframe_iterator.py
@@ -46,8 +46,8 @@ class DataFrameIterator(BatchFromFilesMixin, Iterator):
             Color mode to read images.
         classes: Optional list of strings, classes to use (e.g. `["dogs", "cats"]`).
             If None, all classes in `y_col` will be used.
-        class_mode: one of "categorical", "binary", "sparse", "input",
-            "other" or None. Default: "categorical".
+        class_mode: one of "binary", "categorical", "input", "multi_output",
+            "raw", sparse" or None. Default: "categorical".
             Mode for yielding the targets:
             - `"binary"`: 1D numpy array of binary labels,
             - `"categorical"`: 2D numpy array of one-hot encoded labels.

--- a/keras_preprocessing/image/dataframe_iterator.py
+++ b/keras_preprocessing/image/dataframe_iterator.py
@@ -174,7 +174,8 @@ class DataFrameIterator(BatchFromFilesMixin, Iterator):
         # check that y_col has several column names if class_mode is multi_output
         if (self.class_mode == 'multi_output') and not isinstance(y_col, list):
             raise TypeError(
-                'If class_mode="{}", y_col must be a list. Received {}.'
+                'If class_mode="{}", y_col must be a list. Received {}. '
+                'For regression use class_mode="raw".'
                 .format(self.class_mode, type(y_col).__name__)
             )
         # check that filenames/filepaths column values are all strings
@@ -205,8 +206,8 @@ class DataFrameIterator(BatchFromFilesMixin, Iterator):
                 raise TypeError('If class_mode="{}", y_col="{}" column '
                                 'values must be type string, list or tuple.'
                                 .format(self.class_mode, y_col))
-        # raise warning if classes are given and class_mode other or input
-        if classes and self.class_mode in {"input", None}:
+        # raise warning if classes are given but will be unused
+        if classes and self.class_mode in {"input", "multi_output", "raw", None}:
             warnings.warn('`classes` will be ignored given the class_mode="{}"'
                           .format(self.class_mode))
         # check that if weight column that the values are numerical

--- a/keras_preprocessing/image/dataframe_iterator.py
+++ b/keras_preprocessing/image/dataframe_iterator.py
@@ -174,8 +174,7 @@ class DataFrameIterator(BatchFromFilesMixin, Iterator):
         # check that y_col has several column names if class_mode is multi_output
         if (self.class_mode == 'multi_output') and not isinstance(y_col, list):
             raise TypeError(
-                'If class_mode="{}", y_col must be a list. Received {}. '
-                'For regression use class_mode="raw".'
+                'If class_mode="{}", y_col must be a list. Received {}.'
                 .format(self.class_mode, type(y_col).__name__)
             )
         # check that filenames/filepaths column values are all strings

--- a/keras_preprocessing/image/dataframe_iterator.py
+++ b/keras_preprocessing/image/dataframe_iterator.py
@@ -47,7 +47,7 @@ class DataFrameIterator(BatchFromFilesMixin, Iterator):
         classes: Optional list of strings, classes to use (e.g. `["dogs", "cats"]`).
             If None, all classes in `y_col` will be used.
         class_mode: one of "binary", "categorical", "input", "multi_output",
-            "raw", sparse" or None. Default: "categorical".
+            "raw", "sparse" or None. Default: "categorical".
             Mode for yielding the targets:
             - `"binary"`: 1D numpy array of binary labels,
             - `"categorical"`: 2D numpy array of one-hot encoded labels.

--- a/keras_preprocessing/image/dataframe_iterator.py
+++ b/keras_preprocessing/image/dataframe_iterator.py
@@ -150,7 +150,7 @@ class DataFrameIterator(BatchFromFilesMixin, Iterator):
 
         # create numpy array of raw input if class_mode="other"
         if class_mode == "multi_output":
-            self._targets = df[list(y_col)].values
+            self._targets = [np.array(df[col].tolist()) for col in y_col]
         self.samples = len(self.filenames)
         validated_string = 'validated' if validate_filenames else 'non-validated'
         if class_mode in ["input", "multi_output", None]:
@@ -169,6 +169,12 @@ class DataFrameIterator(BatchFromFilesMixin, Iterator):
         if self.class_mode not in self.allowed_class_modes:
             raise ValueError('Invalid class_mode: {}; expected one of: {}'
                              .format(self.class_mode, self.allowed_class_modes))
+        # check that y_col has several column names if class_mode is multi_output
+        if (self.class_mode == 'multi_output') and not isinstance(y_col, list):
+            raise TypeError(
+                'If class_mode="{}", y_col must be a list. Received {}.'
+                .format(self.class_mode, type(y_col).__name__)
+            )
         # check that filenames/filepaths column values are all strings
         if not all(df[x_col].apply(lambda x: isinstance(x, str))):
             raise TypeError('All values in column x_col={} must be strings.'

--- a/keras_preprocessing/image/image_data_generator.py
+++ b/keras_preprocessing/image/image_data_generator.py
@@ -606,7 +606,7 @@ class ImageDataGenerator(object):
                 - `"sparse"`: 1D numpy array of integer labels,
                 - `"input"`: images identical to input images (mainly used to
                     work with autoencoders),
-                - `"other"`: numpy array of `y_col` data,
+                - `"multi_output"`: list with the values of the different columns,
                 - `None`, no targets are returned (the generator will only yield
                     batches of image data, which is useful to use in
                     `model.predict_generator()`).

--- a/keras_preprocessing/image/image_data_generator.py
+++ b/keras_preprocessing/image/image_data_generator.py
@@ -597,16 +597,17 @@ class ImageDataGenerator(object):
                 which will map to the label indices, will be alphanumeric).
                 The dictionary containing the mapping from class names to class
                 indices can be obtained via the attribute `class_indices`.
-            class_mode: one of "categorical", "binary", "sparse", "input",
-                "other" or None. Default: "categorical".
+            class_mode: one of "binary", "categorical", "input", "multi_output",
+                "raw", sparse" or None. Default: "categorical".
                 Mode for yielding the targets:
                 - `"binary"`: 1D numpy array of binary labels,
                 - `"categorical"`: 2D numpy array of one-hot encoded labels.
                     Supports multi-label output.
-                - `"sparse"`: 1D numpy array of integer labels,
                 - `"input"`: images identical to input images (mainly used to
                     work with autoencoders),
                 - `"multi_output"`: list with the values of the different columns,
+                - `"raw"`: numpy array of values in `y_col` column(s),
+                - `"sparse"`: 1D numpy array of integer labels,
                 - `None`, no targets are returned (the generator will only yield
                     batches of image data, which is useful to use in
                     `model.predict_generator()`).
@@ -652,6 +653,11 @@ class ImageDataGenerator(object):
             warnings.warn('sort is deprecated, batches will be created in the'
                           'same order than the filenames provided if shuffle'
                           'is set to False.', DeprecationWarning)
+        if class_mode == 'other':
+            warnings.warn('`class_mode` "other" is deprecated, please use '
+                          '`class_mode` "raw".', DeprecationWarning)
+            class_mode = 'raw'
+
         return DataFrameIterator(
             dataframe,
             directory,

--- a/keras_preprocessing/image/iterator.py
+++ b/keras_preprocessing/image/iterator.py
@@ -256,8 +256,8 @@ class BatchFromFilesMixin():
                                dtype=self.dtype)
             for i, n_observation in enumerate(index_array):
                 batch_y[i, self.classes[n_observation]] = 1.
-        elif self.class_mode == 'other':
-            batch_y = self.data[index_array]
+        elif self.class_mode == 'multi_output':
+            batch_y = [np.vstack(col) for col in self.labels[index_array].T]
         else:
             return batch_x
         if self.sample_weight is None:
@@ -285,12 +285,5 @@ class BatchFromFilesMixin():
     def sample_weight(self):
         raise NotImplementedError(
             '`sample_weight` property method has not been implemented in {}.'
-            .format(type(self).__name__)
-        )
-
-    @property
-    def data(self):
-        raise NotImplementedError(
-            '`data` property method has not been implemented in {}.'
             .format(type(self).__name__)
         )

--- a/keras_preprocessing/image/iterator.py
+++ b/keras_preprocessing/image/iterator.py
@@ -257,7 +257,7 @@ class BatchFromFilesMixin():
             for i, n_observation in enumerate(index_array):
                 batch_y[i, self.classes[n_observation]] = 1.
         elif self.class_mode == 'multi_output':
-            batch_y = [np.vstack(col) for col in self.labels[index_array].T]
+            batch_y = [output[index_array] for output in self.labels]
         else:
             return batch_x
         if self.sample_weight is None:

--- a/keras_preprocessing/image/iterator.py
+++ b/keras_preprocessing/image/iterator.py
@@ -258,6 +258,8 @@ class BatchFromFilesMixin():
                 batch_y[i, self.classes[n_observation]] = 1.
         elif self.class_mode == 'multi_output':
             batch_y = [output[index_array] for output in self.labels]
+        elif self.class_mode == 'raw':
+            batch_y = self.labels[index_array]
         else:
             return batch_x
         if self.sample_weight is None:

--- a/tests/image_test.py
+++ b/tests/image_test.py
@@ -816,8 +816,6 @@ class TestImage(object):
         assert len(batch_x.shape) == 4
         assert isinstance(batch_y, np.ndarray)
         assert batch_y.shape == (3, 2)
-        print(batch_y)
-        print(df[['output_0', 'output_0']].values[:3])
         assert np.array_equal(batch_y,
                               df[['output_0', 'output_1']].values[:3])
 

--- a/tests/image_test.py
+++ b/tests/image_test.py
@@ -512,11 +512,6 @@ class TestImage(object):
         if np.isnan(df_sparse_iterator.classes).any():
             raise ValueError('Invalid values.')
 
-        df_regression = pd.DataFrame({"filename": filenames,
-                                      "col1": [random.randrange(0, 1)
-                                               for _ in filenames],
-                                      "col2": [random.randrange(0, 1)
-                                               for _ in filenames]})
         # check number of classes and images
         assert len(df_iterator.class_indices) == num_classes
         assert len(df_iterator.classes) == count


### PR DESCRIPTION
### Summary

At the moment `flow_from_dataframe` does not support multi-output, i think is the excellent candidate to do that. Basically if the user sets the mode as `multi_output` then he needs to pass a list of columns and each column will represent each output. This PR enables that functionality. It is now possible to seemingly train multi output. 

In the self-contained example below I show how you could train:
- Two outputs which are single number
- Two outputs, one a single number and another a 1D array
- Two outputs, one a single number and another a 2D array

This functionality will enable several use cases (related to multi-task learning) which currently are not possible or they need to be done in a hacky way.

```
import os
import random
import numpy as np
import pandas as pd
from keras.models import Model
from keras.layers import Flatten, Dense, Input, Reshape
from keras_preprocessing.image import ImageDataGenerator

filenames = []
for i in range(20):
    filename = '/tmp/{}.jpg'.format(i)
    plt.imsave(filename, np.random.uniform(size=(3, 3, 3)))
    filenames.append(filename)

classes = ['dog', 'cat'] * 10
df = pd.DataFrame({'filename': filenames, 'class': classes}).sample(frac=1).reset_index(drop=True)
print(df.dtypes)
df.head()

output = '2d_array' # if mix then one ouput is a scalar the other an image
if output == 'real':
    df = df.assign(output_0=np.random.uniform(size=len(df)), output_1=np.random.uniform(size=len(df)))
elif output == '1d_array':
    df = df.assign(output_0=np.random.uniform(size=len(df)), output_1=[np.random.uniform(size=(2, 2, 1)).flatten() for _ in range(len(df))])
elif output == '2d_array':
    df = df.assign(output_0=np.random.uniform(size=len(df)), output_1=[np.random.uniform(size=(2, 2, 1)) for _ in range(len(df))])

batch_size = 2
generator = ImageDataGenerator(rescale=1/255).flow_from_dataframe(
    df,
    y_col=['output_0', 'output_1'],
    batch_size=batch_size,
    target_size=(3, 3),
    shuffle = False,
    class_mode='multi_output',
)
batch = next(generator)
assert len(batch) == 2
assert np.array_equal(batch[1][0], np.array(df['output_0'].tolist()[:batch_size]))
assert np.array_equal(batch[1][1], np.array(df['output_1'].tolist()[:batch_size]))

inputs = Input(shape=(3, 3 ,3))
x = Flatten()(inputs)
prediction_0 = Dense(units=1, name="prediction_0")(x)
if output == 'real':
    prediction_1 = Dense(units=1, name="prediction_1")(x)
elif output == '1d_array':
    prediction_1 = Dense(units=4, name="prediction_1")(x)
elif output == '2d_array':
    x = Dense(units=4)(x)
    prediction_1 = Reshape((2, 2, 1), name="prediction_1")(x)

model = Model(inputs=inputs, outputs=[prediction_0, prediction_1])

losses = {
    "prediction_0": "mean_squared_error",
    "prediction_1": "binary_crossentropy",
}
loss_weights = {"prediction_0": 1.0, "prediction_1": 1.0}
model.compile(optimizer='adam', loss=losses, loss_weights=loss_weights, metrics=["accuracy"])

model.fit_generator(generator, epochs=2, steps_per_epoch=10)
model.predict_generator(generator, steps=1)
```
### Related Issues
Solves #99 

### PR Overview

- [y ] This PR requires new unit tests [y/n] (make sure tests are included)
- [y ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y ] This PR is backwards compatible [y/n]
- [n ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
