### PR TITLE
Add validate filenames parameter to DataFrameIterator

### DIFF
--- a/keras_preprocessing/image/dataframe_iterator.py
+++ b/keras_preprocessing/image/dataframe_iterator.py
@@ -80,9 +80,9 @@ class DataFrameIterator(BatchFromFilesMixin, Iterator):
             supported. If PIL version 3.4.0 or newer is installed, "box" and
             "hamming" are also supported. By default, "nearest" is used.
         drop_duplicates: Boolean, whether to drop duplicate rows based on filename.
-        validate_images: Boolean, whether to validate image filenames in `x_col`. If
-        `True`, invalid images will be ignored. Disabling this option can lead to
-        speed-up in the instantiation of this class. Default: `True`.
+        validate_filenames: Boolean, whether to validate image filenames in
+        `x_col`. If `True`, invalid images will be ignored. Disabling this option
+        can lead to speed-up in the instantiation of this class. Default: `True`.
     """
     allowed_class_modes = {
         'categorical', 'binary', 'sparse', 'input', 'other', None
@@ -110,7 +110,7 @@ class DataFrameIterator(BatchFromFilesMixin, Iterator):
                  interpolation='nearest',
                  dtype='float32',
                  drop_duplicates=True,
-                 validate_images=True):
+                 validate_filenames=True):
 
         super(DataFrameIterator, self).set_processing_attrs(image_data_generator,
                                                             target_size,
@@ -129,7 +129,7 @@ class DataFrameIterator(BatchFromFilesMixin, Iterator):
         self._check_params(df, x_col, y_col, weight_col, classes)
         if drop_duplicates:
             df.drop_duplicates(x_col, inplace=True)
-        if validate_images:  # check which image files are valid and keep them
+        if validate_filenames:  # check which image files are valid and keep them
             df = self._filter_valid_filepaths(df, x_col)
         if class_mode not in ["other", "input", None]:
             df, classes = self._filter_classes(df, y_col, classes)
@@ -156,7 +156,7 @@ class DataFrameIterator(BatchFromFilesMixin, Iterator):
             if "object" in list(df[y_col].dtypes):
                 raise TypeError("y_col column/s must be numeric datatypes.")
         self.samples = len(self.filenames)
-        validated_string = 'validated' if validate_images else 'non-validated'
+        validated_string = 'validated' if validate_filenames else 'non-validated'
         if class_mode in ["other", "input", None]:
             print('Found {} {} image filenames.'
                   .format(self.samples, validated_string))

--- a/keras_preprocessing/image/dataframe_iterator.py
+++ b/keras_preprocessing/image/dataframe_iterator.py
@@ -80,9 +80,9 @@ class DataFrameIterator(BatchFromFilesMixin, Iterator):
             supported. If PIL version 3.4.0 or newer is installed, "box" and
             "hamming" are also supported. By default, "nearest" is used.
         drop_duplicates: Boolean, whether to drop duplicate rows based on filename.
-        validate_images: Boolean, whether to validate image filenames in `x_col`.
-            Disabling this option can lead to speed-up in the instantiation of
-            this class. Default: `True`.
+        validate_images: Boolean, whether to validate image filenames in `x_col`. If
+        `True`, invalid images will be ignored. Disabling this option can lead to
+        speed-up in the instantiation of this class. Default: `True`.
     """
     allowed_class_modes = {
         'categorical', 'binary', 'sparse', 'input', 'other', None

--- a/keras_preprocessing/image/dataframe_iterator.py
+++ b/keras_preprocessing/image/dataframe_iterator.py
@@ -10,7 +10,7 @@ import warnings
 import numpy as np
 
 from .iterator import BatchFromFilesMixin, Iterator
-from .utils import get_extension
+from .utils import validate_filename
 
 
 class DataFrameIterator(BatchFromFilesMixin, Iterator):
@@ -80,6 +80,9 @@ class DataFrameIterator(BatchFromFilesMixin, Iterator):
             supported. If PIL version 3.4.0 or newer is installed, "box" and
             "hamming" are also supported. By default, "nearest" is used.
         drop_duplicates: Boolean, whether to drop duplicate rows based on filename.
+        validate_images: Boolean, whether to validate image filenames in `x_col`.
+            Disabling this option can lead to speed-up in the instantiation of
+            this class. Default: `True`.
     """
     allowed_class_modes = {
         'categorical', 'binary', 'sparse', 'input', 'other', None
@@ -106,7 +109,8 @@ class DataFrameIterator(BatchFromFilesMixin, Iterator):
                  subset=None,
                  interpolation='nearest',
                  dtype='float32',
-                 drop_duplicates=True):
+                 drop_duplicates=True,
+                 validate_images=True):
 
         super(DataFrameIterator, self).set_processing_attrs(image_data_generator,
                                                             target_size,
@@ -125,8 +129,8 @@ class DataFrameIterator(BatchFromFilesMixin, Iterator):
         self._check_params(df, x_col, y_col, weight_col, classes)
         if drop_duplicates:
             df.drop_duplicates(x_col, inplace=True)
-        # check which image files are valid and keep them
-        df = self._filter_valid_filepaths(df, x_col)
+        if validate_images:  # check which image files are valid and keep them
+            df = self._filter_valid_filepaths(df, x_col)
         if class_mode not in ["other", "input", None]:
             df, classes = self._filter_classes(df, y_col, classes)
             num_classes = len(classes)
@@ -152,11 +156,13 @@ class DataFrameIterator(BatchFromFilesMixin, Iterator):
             if "object" in list(df[y_col].dtypes):
                 raise TypeError("y_col column/s must be numeric datatypes.")
         self.samples = len(self.filenames)
+        validated_string = 'validated' if validate_images else 'non-validated'
         if class_mode in ["other", "input", None]:
-            print('Found {} images.'.format(self.samples))
+            print('Found {} {} image filenames.'
+                  .format(self.samples, validated_string))
         else:
-            print('Found {} images belonging to {} classes.'
-                  .format(self.samples, num_classes))
+            print('Found {} {} image filenames belonging to {} classes.'
+                  .format(self.samples, validated_string, num_classes))
         super(DataFrameIterator, self).__init__(self.samples,
                                                 batch_size,
                                                 shuffle,
@@ -254,9 +260,15 @@ class DataFrameIterator(BatchFromFilesMixin, Iterator):
         filepaths = df[x_col].map(
             lambda fname: os.path.join(self.directory or '', fname)
         )
-        format_check = filepaths.map(get_extension).isin(self.white_list_formats)
-        existence_check = filepaths.map(os.path.isfile)
-        return df[format_check & existence_check]
+        mask = filepaths.apply(validate_filename, args=(self.white_list_formats,))
+        n_invalid = (~mask).sum()
+        if n_invalid:
+            warnings.warn(
+                'Found {} invalid image filename(s) in x_col="{}". '
+                'These filename(s) will be ignored.'
+                .format(n_invalid, x_col)
+            )
+        return df[mask]
 
     @property
     def filepaths(self):

--- a/keras_preprocessing/image/image_data_generator.py
+++ b/keras_preprocessing/image/image_data_generator.py
@@ -634,8 +634,9 @@ class ImageDataGenerator(object):
             drop_duplicates: Boolean, whether to drop duplicate rows
                 based on filename.
             validate_images: Boolean, whether to validate image filenames in
-                `x_col`. Disabling this option can lead to speed-up in the
-                execution of this function. Default: `True`.
+                `x_col`. If `True`, invalid images will be ignored. Disabling this
+                option can lead to speed-up in the execution of this function.
+                Default: `True`.
 
         # Returns
             A `DataFrameIterator` yielding tuples of `(x, y)`

--- a/keras_preprocessing/image/image_data_generator.py
+++ b/keras_preprocessing/image/image_data_generator.py
@@ -557,6 +557,7 @@ class ImageDataGenerator(object):
                             subset=None,
                             interpolation='nearest',
                             drop_duplicates=True,
+                            validate_images=True,
                             **kwargs):
         """Takes the dataframe and the path to a directory
          and generates batches of augmented/normalized data.
@@ -632,6 +633,9 @@ class ImageDataGenerator(object):
                 `"hamming"` are also supported. By default, `"nearest"` is used.
             drop_duplicates: Boolean, whether to drop duplicate rows
                 based on filename.
+            validate_images: Boolean, whether to validate image filenames in
+                `x_col`. Disabling this option can lead to speed-up in the
+                execution of this function. Default: `True`.
 
         # Returns
             A `DataFrameIterator` yielding tuples of `(x, y)`
@@ -667,7 +671,8 @@ class ImageDataGenerator(object):
             save_format=save_format,
             subset=subset,
             interpolation=interpolation,
-            drop_duplicates=drop_duplicates
+            drop_duplicates=drop_duplicates,
+            validate_images=True
         )
 
     def standardize(self, x):

--- a/keras_preprocessing/image/image_data_generator.py
+++ b/keras_preprocessing/image/image_data_generator.py
@@ -557,7 +557,7 @@ class ImageDataGenerator(object):
                             subset=None,
                             interpolation='nearest',
                             drop_duplicates=True,
-                            validate_images=True,
+                            validate_filenames=True,
                             **kwargs):
         """Takes the dataframe and the path to a directory
          and generates batches of augmented/normalized data.
@@ -633,7 +633,7 @@ class ImageDataGenerator(object):
                 `"hamming"` are also supported. By default, `"nearest"` is used.
             drop_duplicates: Boolean, whether to drop duplicate rows
                 based on filename.
-            validate_images: Boolean, whether to validate image filenames in
+            validate_filenames: Boolean, whether to validate image filenames in
                 `x_col`. If `True`, invalid images will be ignored. Disabling this
                 option can lead to speed-up in the execution of this function.
                 Default: `True`.
@@ -673,7 +673,7 @@ class ImageDataGenerator(object):
             subset=subset,
             interpolation=interpolation,
             drop_duplicates=drop_duplicates,
-            validate_images=True
+            validate_filenames=validate_filenames
         )
 
     def standardize(self, x):

--- a/keras_preprocessing/image/iterator.py
+++ b/keras_preprocessing/image/iterator.py
@@ -31,7 +31,7 @@ class Iterator(IteratorType):
         shuffle: Boolean, whether to shuffle the data between epochs.
         seed: Random seeding for data shuffling.
     """
-    white_list_formats = {'png', 'jpg', 'jpeg', 'bmp', 'ppm', 'tif', 'tiff'}
+    white_list_formats = ('png', 'jpg', 'jpeg', 'bmp', 'ppm', 'tif', 'tiff')
 
     def __init__(self, n, batch_size, shuffle, seed):
         self.n = n

--- a/keras_preprocessing/image/utils.py
+++ b/keras_preprocessing/image/utils.py
@@ -43,7 +43,8 @@ def validate_filename(filename, white_list_formats):
     # Returns
         A boolean value indicating if the filename is valid or not
     """
-    return filename.endswith(white_list_formats) and os.path.isfile(filename)
+    return (filename.lower().endswith(white_list_formats) and
+            os.path.isfile(filename))
 
 
 def save_img(path,

--- a/keras_preprocessing/image/utils.py
+++ b/keras_preprocessing/image/utils.py
@@ -33,12 +33,17 @@ if pil_image is not None:
         _PIL_INTERPOLATION_METHODS['lanczos'] = pil_image.LANCZOS
 
 
-def get_extension(filename):
-    """Get extension of the filename
+def validate_filename(filename, white_list_formats):
+    """Check if a filename refers to a valid file
 
-    There are newer methods to achieve this but this method is backwards compatible.
+    # Arguments
+        filename: String, absolute path to a file
+        white_list_formats: Set, allowed file extensions
+
+    # Returns
+        A boolean value indicating if the filename is valid or not
     """
-    return os.path.splitext(filename)[1].strip('.').lower()
+    return filename.endswith(white_list_formats) and os.path.isfile(filename)
 
 
 def save_img(path,
@@ -164,7 +169,7 @@ def _iter_valid_files(directory, white_list_formats, follow_links):
             if fname.lower().endswith('.tiff'):
                 warnings.warn('Using ".tiff" files with multiple bands '
                               'will cause distortion. Please verify your output.')
-            if get_extension(fname) in white_list_formats:
+            if fname.lower().endswith(white_list_formats):
                 yield root, fname
 
 

--- a/tests/image_test.py
+++ b/tests/image_test.py
@@ -1300,6 +1300,16 @@ class TestImage(object):
         found_images = image.list_pictures(str(tmpdir), ext='png')
         assert len(found_images) == 6
 
+    def test_validate_filename(self, tmpdir):
+        valid_extensions = ('png', 'jpg')
+        filename = tmpdir.ensure('test.png')
+        assert image.validate_filename(str(filename), valid_extensions)
+        filename = tmpdir.ensure('test.PnG')
+        assert image.validate_filename(str(filename), valid_extensions)
+        filename = tmpdir.ensure('test.some_extension')
+        assert not image.validate_filename(str(filename), valid_extensions)
+        assert not image.validate_filename('some_test_file.png', valid_extensions)
+
 
 if __name__ == '__main__':
     pytest.main([__file__])

--- a/tests/image_test.py
+++ b/tests/image_test.py
@@ -590,7 +590,7 @@ class TestImage(object):
         with pytest.raises(ValueError):
             image.ImageDataGenerator(brightness_range=0.1)
 
-    def test_dataframe_iterator_validate_validate_filenames(self, tmpdir):
+    def test_dataframe_iterator_validate_filenames(self, tmpdir):
         # save the images in the paths
         count = 0
         filenames = []

--- a/tests/image_test.py
+++ b/tests/image_test.py
@@ -590,6 +590,28 @@ class TestImage(object):
         with pytest.raises(ValueError):
             image.ImageDataGenerator(brightness_range=0.1)
 
+    def test_dataframe_iterator_validate_validate_filenames(self, tmpdir):
+        # save the images in the paths
+        count = 0
+        filenames = []
+        for test_images in self.all_test_images:
+            for im in test_images:
+                filename = 'image-{}.png'.format(count)
+                im.save(str(tmpdir / filename))
+                filenames.append(filename)
+                count += 1
+        df = pd.DataFrame({"filename": filenames + ['test.jpp', 'test.jpg']})
+        generator = image.ImageDataGenerator()
+        df_iterator = generator.flow_from_dataframe(df,
+                                                    str(tmpdir),
+                                                    class_mode="input")
+        assert len(df_iterator.filenames) == len(df['filename']) - 2
+        df_iterator = generator.flow_from_dataframe(df,
+                                                    str(tmpdir),
+                                                    class_mode="input",
+                                                    validate_filenames=False)
+        assert len(df_iterator.filenames) == len(df['filename'])
+
     def test_dataframe_iterator_sample_weights(self, tmpdir):
         # save the images in the paths
         count = 0


### PR DESCRIPTION
### Summary
This PR allows the user to skip the validation of images filepaths in the pandas DataFrame to speed up the instantiation process. Slow instantiation times have been reported (#171) for a big amount of filenames.  
In addition this PR adds a warning to the user if validation is on and non-valid image filenames are found.
By default image filenames are validated.

### Related Issues
#171 

### PR Overview

- [ y] This PR requires new unit tests [y/n] (make sure tests are included)
- [ y] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [ y] This PR is backwards compatible [y/n]
- [ n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
