### PR TITLE
Remove the parameter drop_duplicates

### DIFF
--- a/keras_preprocessing/image/dataframe_iterator.py
+++ b/keras_preprocessing/image/dataframe_iterator.py
@@ -80,7 +80,6 @@ class DataFrameIterator(BatchFromFilesMixin, Iterator):
             If PIL version 1.1.3 or newer is installed, "lanczos" is also
             supported. If PIL version 3.4.0 or newer is installed, "box" and
             "hamming" are also supported. By default, "nearest" is used.
-        drop_duplicates: Boolean, whether to drop duplicate rows based on filename.
         validate_filenames: Boolean, whether to validate image filenames in
         `x_col`. If `True`, invalid images will be ignored. Disabling this option
         can lead to speed-up in the instantiation of this class. Default: `True`.
@@ -110,7 +109,6 @@ class DataFrameIterator(BatchFromFilesMixin, Iterator):
                  subset=None,
                  interpolation='nearest',
                  dtype='float32',
-                 drop_duplicates=True,
                  validate_filenames=True):
 
         super(DataFrameIterator, self).set_processing_attrs(image_data_generator,
@@ -128,8 +126,6 @@ class DataFrameIterator(BatchFromFilesMixin, Iterator):
         self.dtype = dtype
         # check that inputs match the required class_mode
         self._check_params(df, x_col, y_col, weight_col, classes)
-        if drop_duplicates:
-            df.drop_duplicates(x_col, inplace=True)
         if validate_filenames:  # check which image files are valid and keep them
             df = self._filter_valid_filepaths(df, x_col)
         if class_mode not in ["input", "multi_output", "raw", None]:

--- a/keras_preprocessing/image/image_data_generator.py
+++ b/keras_preprocessing/image/image_data_generator.py
@@ -556,7 +556,6 @@ class ImageDataGenerator(object):
                             save_format='png',
                             subset=None,
                             interpolation='nearest',
-                            drop_duplicates=True,
                             validate_filenames=True,
                             **kwargs):
         """Takes the dataframe and the path to a directory
@@ -632,8 +631,6 @@ class ImageDataGenerator(object):
                 If PIL version 1.1.3 or newer is installed, `"lanczos"` is also
                 supported. If PIL version 3.4.0 or newer is installed, `"box"` and
                 `"hamming"` are also supported. By default, `"nearest"` is used.
-            drop_duplicates: Boolean, whether to drop duplicate rows
-                based on filename.
             validate_filenames: Boolean, whether to validate image filenames in
                 `x_col`. If `True`, invalid images will be ignored. Disabling this
                 option can lead to speed-up in the execution of this function.
@@ -657,6 +654,8 @@ class ImageDataGenerator(object):
             warnings.warn('`class_mode` "other" is deprecated, please use '
                           '`class_mode` "raw".', DeprecationWarning)
             class_mode = 'raw'
+        if 'drop_duplicates' in kwargs:
+            warnings.warn('drop_duplicates is deprecated.', DeprecationWarning)
 
         return DataFrameIterator(
             dataframe,
@@ -678,7 +677,6 @@ class ImageDataGenerator(object):
             save_format=save_format,
             subset=subset,
             interpolation=interpolation,
-            drop_duplicates=drop_duplicates,
             validate_filenames=validate_filenames
         )
 

--- a/keras_preprocessing/image/image_data_generator.py
+++ b/keras_preprocessing/image/image_data_generator.py
@@ -655,7 +655,9 @@ class ImageDataGenerator(object):
                           '`class_mode` "raw".', DeprecationWarning)
             class_mode = 'raw'
         if 'drop_duplicates' in kwargs:
-            warnings.warn('drop_duplicates is deprecated.', DeprecationWarning)
+            warnings.warn('drop_duplicates is deprecated, you can drop duplicates '
+                          'by using the pandas.DataFrame.drop_duplicates method.',
+                          DeprecationWarning)
 
         return DataFrameIterator(
             dataframe,

--- a/tests/image_test.py
+++ b/tests/image_test.py
@@ -1022,7 +1022,7 @@ class TestImage(object):
             assert np.array_equal(a1, a2)
             assert np.array_equal(a1, a3)
             assert np.array_equal(a1, a4)
-            assert np.array_equal(a1, a5)f
+            assert np.array_equal(a1, a5)
 
     def test_dataframe_iterator_with_subdirs(self, tmpdir):
         num_classes = 2

--- a/tests/image_test.py
+++ b/tests/image_test.py
@@ -1022,40 +1022,7 @@ class TestImage(object):
             assert np.array_equal(a1, a2)
             assert np.array_equal(a1, a3)
             assert np.array_equal(a1, a4)
-            assert np.array_equal(a1, a5)
-
-    def test_dataframe_iterator_with_drop_duplicates(self, tmpdir):
-
-        # save the images in the tmpdir
-        count = 0
-        filenames = []
-        for test_images in self.all_test_images:
-            for im in test_images:
-                filename = "image-{:0>5}.png".format(count)
-                filenames.append(filename)
-                im.save(str(tmpdir / filename))
-                count += 1
-
-        # prepare input_filenames
-        n_files = len(filenames)
-        idx_rand, idx_rand2 = np.random.randint(1, n_files, size=2)
-        input_filenames = filenames[::-1]  # reversed
-        input_filenames2 = filenames[:idx_rand] + filenames[:idx_rand2]
-
-        # create dataframes
-        df = pd.DataFrame({"filename": input_filenames})
-        df2 = pd.DataFrame({"filename": input_filenames2})
-
-        # create iterators
-        generator = image.ImageDataGenerator()
-        df_drop_iterator = generator.flow_from_dataframe(
-            df, str(tmpdir), class_mode=None, drop_duplicates=True)
-        df_no_drop_iterator = generator.flow_from_dataframe(
-            df2, str(tmpdir), class_mode=None, drop_duplicates=False)
-
-        # Test drop_duplicates
-        assert df_drop_iterator.n == len(set(input_filenames))
-        assert df_no_drop_iterator.n == len(input_filenames2)
+            assert np.array_equal(a1, a5)f
 
     def test_dataframe_iterator_with_subdirs(self, tmpdir):
         num_classes = 2


### PR DESCRIPTION
### Summary
Currently the `drop_diuplicates` parameter from `flow_from_dataframe`and ``DataFrameIterator` can deduplicate filenames from the user's input. My arguments for removing it are:

1.- In the same way that `sort` and `has_ext` have nothing to do with the logic the user expects and that should be handled by the `DataFrameIterator`, `drop_duplicates` also has nothing to do with the logic the class should handle. Look #123 and #122 for more explanation.
2.- It produces an unexpected behavior to the user, and several issues have been raised already because of this: #96 #175 and #181

### Related Issues
 #96 #175  #181

### PR Overview

- [n ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ y] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [ y] This PR is backwards compatible [y/n]
- [ n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
