### PR TITLE
Add DeprecationWarning type to warning message

### DIFF
--- a/keras_preprocessing/image/image_data_generator.py
+++ b/keras_preprocessing/image/image_data_generator.py
@@ -651,7 +651,7 @@ class ImageDataGenerator(object):
         if 'sort' in kwargs:
             warnings.warn('sort is deprecated, batches will be created in the'
                           'same order than the filenames provided if shuffle'
-                          'is set to False.')
+                          'is set to False.', DeprecationWarning)
         return DataFrameIterator(
             dataframe,
             directory,


### PR DESCRIPTION
### Summary
Warning about deprecation of the `sort` parameter is missing the deprecation warning type.

### PR Overview

- [n ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [ y] This PR is backwards compatible [y/n]
- [ n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
