### PR TITLE
Add lower limit in iterator.__getitem__

### DIFF
--- a/keras_preprocessing/image/iterator.py
+++ b/keras_preprocessing/image/iterator.py
@@ -55,6 +55,8 @@ class Iterator(IteratorType):
                              'but the Sequence '
                              'has length {length}'.format(idx=idx,
                                                           length=len(self)))
+        elif idx < 0:
+            raise ValueError('Could not retrieve item with negative index')
         if self.seed is not None:
             np.random.seed(self.seed + self.total_batches_seen)
         self.total_batches_seen += 1


### PR DESCRIPTION


### Summary
Add lower limit in `iterator.__getitem__` to avoid dead loop when iterating over the ImageDataGenerator

### Related Issues

### PR Overview

- [n] This PR requires new unit tests [y/n] (make sure tests are included)
- [n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
