### PR TITLE
Allow numpy.array as classes in DataFrameIterator

### DIFF
--- a/keras_preprocessing/image/dataframe_iterator.py
+++ b/keras_preprocessing/image/dataframe_iterator.py
@@ -44,7 +44,7 @@ class DataFrameIterator(BatchFromFilesMixin, Iterator):
         target_size: tuple of integers, dimensions to resize input images to.
         color_mode: One of `"rgb"`, `"rgba"`, `"grayscale"`.
             Color mode to read images.
-        classes: Optional list of strings, classes to use (e.g. `["dogs", "cats"]`).
+        classes: Optional numpy array/list of strings, classes to use (e.g. `["dogs", "cats"]`).
             If None, all classes in `y_col` will be used.
         class_mode: one of "binary", "categorical", "input", "multi_output",
             "raw", "sparse" or None. Default: "categorical".
@@ -185,7 +185,7 @@ class DataFrameIterator(BatchFromFilesMixin, Iterator):
                                 .format(self.class_mode, y_col))
         # check that if binary there are only 2 different classes
         if self.class_mode == 'binary':
-            if classes:
+            if classes is not None:
                 classes = set(classes)
                 if len(classes) != 2:
                     raise ValueError('If class_mode="binary" there must be 2 '
@@ -202,7 +202,7 @@ class DataFrameIterator(BatchFromFilesMixin, Iterator):
                                 'values must be type string, list or tuple.'
                                 .format(self.class_mode, y_col))
         # raise warning if classes are given but will be unused
-        if classes and self.class_mode in {"input", "multi_output", "raw", None}:
+        if classes is not None and self.class_mode in {"input", "multi_output", "raw", None}:
             warnings.warn('`classes` will be ignored given the class_mode="{}"'
                           .format(self.class_mode))
         # check that if weight column that the values are numerical
@@ -235,7 +235,7 @@ class DataFrameIterator(BatchFromFilesMixin, Iterator):
                     .format(type(labels), y_col)
                 )
 
-        if classes:
+        if classes is not None:
             classes = set(classes)  # sort and prepare for membership lookup
             df[y_col] = df[y_col].apply(lambda x: remove_classes(x, classes))
         else:

--- a/tests/image_test.py
+++ b/tests/image_test.py
@@ -1072,6 +1072,21 @@ class TestImage(object):
         assert df_iterator.n == len(filenames)
         assert set(df_iterator.filenames) == set(filenames)
 
+    def test_dataframe_iterator_classes_with_numpy_array(self, tmpdir):
+        # create dataframe
+        df = pd.DataFrame({"filename": ['image-1.png'],
+                           "class": ['cat']})
+
+        # create numpy array of class names
+        classes = np.array(['dog', 'cat'])
+
+        # create iterator
+        generator = image.ImageDataGenerator()
+        df_iterator = generator.flow_from_dataframe(
+            df, str(tmpdir), classes=classes, class_mode='binary')
+
+        assert len(df_iterator.class_indices) == len(classes)
+
     def test_img_utils(self):
         height, width = 10, 8
 


### PR DESCRIPTION
### Summary
Numpy array not allowed to be used as `classes` in `DataFrameIterator`.

I understand that according to the docs:
Argument `classes`: Optional list of strings, classes to use (e.g. `["dogs", "cats"]`).
I wonder if we could expand it to include `numpy.array`?

Usually, I would derive my list of classes using `dataset['Category'].unique()` where `dataset` is a `pandas.DataFrame`, this returns a `numpy.array`.

A `numpy.array` will cause `ValueError` due to `numpy.array`'s boolean operation. Below is a screenshot of a small example:
![image](https://user-images.githubusercontent.com/16360559/54595253-373ac580-4a6d-11e9-9f33-3365648e1b86.png)

P.S. I am not sure if this is intended and I am a novice in open source, so please bear with me.

### Related Issues

### PR Overview

- [n] This PR requires new unit tests [y/n] (make sure tests are included)
- [y] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
