### PR TITLE
Feature/fix performance issue

### DIFF
--- a/keras_preprocessing/image/dataframe_iterator.py
+++ b/keras_preprocessing/image/dataframe_iterator.py
@@ -121,7 +121,7 @@ class DataFrameIterator(BatchFromFilesMixin, Iterator):
                                                             subset,
                                                             interpolation)
         df = dataframe.copy()
-        self.directory = directory
+        self.directory = directory or ''
         self.class_mode = class_mode
         self.dtype = dtype
         # check that inputs match the required class_mode
@@ -157,14 +157,13 @@ class DataFrameIterator(BatchFromFilesMixin, Iterator):
         else:
             print('Found {} {} image filenames belonging to {} classes.'
                   .format(self.samples, validated_string, num_classes))
+        self._filepaths = [
+            os.path.join(self.directory, fname) for fname in self.filenames
+        ]
         super(DataFrameIterator, self).__init__(self.samples,
                                                 batch_size,
                                                 shuffle,
                                                 seed)
-        root = self.directory or ''
-        self.path_to_files = [
-            os.path.join(root, fname) for fname in self.filenames
-        ]
 
     def _check_params(self, df, x_col, y_col, weight_col, classes):
         # check class mode is one of the currently supported
@@ -262,7 +261,7 @@ class DataFrameIterator(BatchFromFilesMixin, Iterator):
             absolute paths to image files
         """
         filepaths = df[x_col].map(
-            lambda fname: os.path.join(self.directory or '', fname)
+            lambda fname: os.path.join(self.directory, fname)
         )
         mask = filepaths.apply(validate_filename, args=(self.white_list_formats,))
         n_invalid = (~mask).sum()
@@ -276,7 +275,7 @@ class DataFrameIterator(BatchFromFilesMixin, Iterator):
 
     @property
     def filepaths(self):
-        return self.path_to_files
+        return self._filepaths
 
     @property
     def labels(self):

--- a/keras_preprocessing/image/dataframe_iterator.py
+++ b/keras_preprocessing/image/dataframe_iterator.py
@@ -154,6 +154,8 @@ class DataFrameIterator(BatchFromFilesMixin, Iterator):
                                                 batch_size,
                                                 shuffle,
                                                 seed)
+        root = self.directory or ''
+        self.path_to_files = [os.path.join(root, fname) for fname in self.filenames]
 
     def _check_params(self, df, x_col, y_col, classes):
         # check class mode is one of the currently supported
@@ -249,8 +251,7 @@ class DataFrameIterator(BatchFromFilesMixin, Iterator):
 
     @property
     def filepaths(self):
-        root = self.directory or ''
-        return [os.path.join(root, fname) for fname in self.filenames]
+        return self.path_to_files
 
     @property
     def labels(self):

--- a/keras_preprocessing/image/dataframe_iterator.py
+++ b/keras_preprocessing/image/dataframe_iterator.py
@@ -162,7 +162,9 @@ class DataFrameIterator(BatchFromFilesMixin, Iterator):
                                                 shuffle,
                                                 seed)
         root = self.directory or ''
-        self.path_to_files = [os.path.join(root, fname) for fname in self.filenames]
+        self.path_to_files = [
+            os.path.join(root, fname) for fname in self.filenames
+        ]
 
     def _check_params(self, df, x_col, y_col, weight_col, classes):
         # check class mode is one of the currently supported

--- a/keras_preprocessing/image/directory_iterator.py
+++ b/keras_preprocessing/image/directory_iterator.py
@@ -140,9 +140,11 @@ class DirectoryIterator(BatchFromFilesMixin, Iterator):
                                                 shuffle,
                                                 seed)
 
+        self.path_to_files = [os.path.join(self.directory, fname) for fname in self.filenames]
+
     @property
     def filepaths(self):
-        return [os.path.join(self.directory, fname) for fname in self.filenames]
+        return self.path_to_files
 
     @property
     def labels(self):

--- a/keras_preprocessing/image/directory_iterator.py
+++ b/keras_preprocessing/image/directory_iterator.py
@@ -90,7 +90,7 @@ class DirectoryIterator(BatchFromFilesMixin, Iterator):
                                                             save_format,
                                                             subset,
                                                             interpolation)
-        self.directory = directory
+        self.directory = directory or ''
         self.classes = classes
         if class_mode not in self.allowed_class_modes:
             raise ValueError('Invalid class_mode: {}; expected one of: {}'
@@ -135,18 +135,17 @@ class DirectoryIterator(BatchFromFilesMixin, Iterator):
               (self.samples, self.num_classes))
         pool.close()
         pool.join()
+        self._filepaths = [
+            os.path.join(self.directory, fname) for fname in self.filenames
+        ]
         super(DirectoryIterator, self).__init__(self.samples,
                                                 batch_size,
                                                 shuffle,
                                                 seed)
 
-        self.path_to_files = [
-            os.path.join(self.directory, fname) for fname in self.filenames
-        ]
-
     @property
     def filepaths(self):
-        return self.path_to_files
+        return self._filepaths
 
     @property
     def labels(self):

--- a/keras_preprocessing/image/directory_iterator.py
+++ b/keras_preprocessing/image/directory_iterator.py
@@ -90,7 +90,7 @@ class DirectoryIterator(BatchFromFilesMixin, Iterator):
                                                             save_format,
                                                             subset,
                                                             interpolation)
-        self.directory = directory or ''
+        self.directory = directory
         self.classes = classes
         if class_mode not in self.allowed_class_modes:
             raise ValueError('Invalid class_mode: {}; expected one of: {}'

--- a/keras_preprocessing/image/directory_iterator.py
+++ b/keras_preprocessing/image/directory_iterator.py
@@ -140,7 +140,9 @@ class DirectoryIterator(BatchFromFilesMixin, Iterator):
                                                 shuffle,
                                                 seed)
 
-        self.path_to_files = [os.path.join(self.directory, fname) for fname in self.filenames]
+        self.path_to_files = [
+            os.path.join(self.directory, fname) for fname in self.filenames
+        ]
 
     @property
     def filepaths(self):


### PR DESCRIPTION
### Summary
We noticed a performance issue with the latest release(1.0.9). 
We did a root cause analysis and we found the source of issue.
The "[os.path.join(self.directory, fname) for fname in self.filenames]" was refactorized into @property function and had been called with each iteartion by _get_batches_of_transformed_samples() function:
e.g: 100(iteration) x 155.096(number of iamges) = 15.509.600(path generated)

I moved the filepath generator to the _init_() function from the @property function
So, the file_paths will be generated just one time with _init()_ function

### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [ ] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
