### PR TITLE
fix support for numpy mmap backend (np.memmap)

### DIFF
--- a/keras_preprocessing/image/image_data_generator.py
+++ b/keras_preprocessing/image/image_data_generator.py
@@ -427,7 +427,8 @@ class ImageDataGenerator(object):
             save_to_dir=save_to_dir,
             save_prefix=save_prefix,
             save_format=save_format,
-            subset=subset
+            subset=subset,
+            dtype=x.dtype
         )
 
     def flow_from_directory(self,

--- a/keras_preprocessing/image/numpy_array_iterator.py
+++ b/keras_preprocessing/image/numpy_array_iterator.py
@@ -109,7 +109,7 @@ class NumpyArrayIterator(Iterator):
                 if y is not None:
                     y = y[split_idx:]
 
-        self.x = np.asarray(x, dtype=self.dtype)
+        self.x = np.asanyarray(x, dtype=self.dtype)
         self.x_misc = x_misc
         if self.x.ndim != 4:
             raise ValueError('Input data in `NumpyArrayIterator` '


### PR DESCRIPTION
### Summary

ImageDataGenerator.flow needs to create an NumpyArrayIterator
which honors the input's dtype.
NumpyArrayIterator needs to use numpy.asanyarray to work with numpy.memmap.

### Related Issues

### PR Overview

- [N] This PR requires new unit tests [y/n] (make sure tests are included)
- [N] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [Y] This PR is backwards compatible [y/n]
- [N] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
