### PR TITLE
add ignore_class_split option for non categorical labels in image data generator

### DIFF
--- a/keras_preprocessing/image/image_data_generator.py
+++ b/keras_preprocessing/image/image_data_generator.py
@@ -374,6 +374,7 @@ class ImageDataGenerator(object):
              save_to_dir=None,
              save_prefix='',
              save_format='png',
+             ignore_class_split=False,
              subset=None):
         """Takes data & label arrays, generates batches of augmented data.
 
@@ -404,6 +405,9 @@ class ImageDataGenerator(object):
                 (only relevant if `save_to_dir` is set).
             save_format: one of "png", "jpeg"
                 (only relevant if `save_to_dir` is set). Default: "png".
+            ignore_class_split: Boolean (default: False), ignore difference
+                in number of classes in labels across train and validation
+                split (useful for non-classification tasks)
             subset: Subset of data (`"training"` or `"validation"`) if
                 `validation_split` is set in `ImageDataGenerator`.
 
@@ -429,6 +433,7 @@ class ImageDataGenerator(object):
             save_to_dir=save_to_dir,
             save_prefix=save_prefix,
             save_format=save_format,
+            ignore_class_split=ignore_class_split,
             subset=subset
         )
 

--- a/keras_preprocessing/image/numpy_array_iterator.py
+++ b/keras_preprocessing/image/numpy_array_iterator.py
@@ -39,6 +39,9 @@ class NumpyArrayIterator(Iterator):
             (if `save_to_dir` is set).
         subset: Subset of data (`"training"` or `"validation"`) if
             validation_split is set in ImageDataGenerator.
+        ignore_class_split: Boolean (default: False), ignore difference
+                in number of classes in labels across train and validation
+                split (useful for non-classification tasks)
         dtype: Dtype to use for the generated arrays.
     """
 
@@ -55,6 +58,7 @@ class NumpyArrayIterator(Iterator):
                  save_prefix='',
                  save_format='png',
                  subset=None,
+                 ignore_class_split=False,
                  dtype='float32'):
         self.dtype = dtype
         if (type(x) is tuple) or (type(x) is list):
@@ -89,7 +93,7 @@ class NumpyArrayIterator(Iterator):
                                  '; expected "training" or "validation".')
             split_idx = int(len(x) * image_data_generator._validation_split)
 
-            if (y is not None and not
+            if (y is not None and not ignore_class_split and not
                 np.array_equal(np.unique(y[:split_idx]),
                                np.unique(y[split_idx:]))):
                 raise ValueError('Training and validation subsets '

--- a/tests/image/dataframe_iterator_test.py
+++ b/tests/image/dataframe_iterator_test.py
@@ -256,7 +256,7 @@ def test_dataframe_iterator_class_mode_categorical_multi_label(all_test_images,
     assert isinstance(batch_y, np.ndarray)
     assert batch_y.shape == (len(batch_x), 2)
     for labels in batch_y:
-        assert all(l in {0, 1} for l in labels)
+        assert all(label in {0, 1} for label in labels)
 
     # on first 3 batches
     df = pd.DataFrame({
@@ -272,7 +272,7 @@ def test_dataframe_iterator_class_mode_categorical_multi_label(all_test_images,
     assert isinstance(batch_y, np.ndarray)
     assert batch_y.shape == (len(batch_x), 3)
     for labels in batch_y:
-        assert all(l in {0, 1} for l in labels)
+        assert all(label in {0, 1} for label in labels)
     assert (batch_y[0] == np.array([1, 1, 0])).all()
     assert (batch_y[1] == np.array([0, 1, 0])).all()
     assert (batch_y[2] == np.array([0, 0, 1])).all()

--- a/tests/image/image_data_generator_test.py
+++ b/tests/image/image_data_generator_test.py
@@ -81,6 +81,12 @@ def test_image_data_generator_with_validation_split(all_test_images):
                            shuffle=False, batch_size=10,
                            subset='validation')
 
+        # test non categorical labels with validation split
+        generator.flow(images, labels,
+                       shuffle=False, batch_size=10,
+                       ignore_class_split=True,
+                       subset='validation')
+
         labels = np.concatenate([
             np.zeros((int(len(images) / 4),)),
             np.ones((int(len(images) / 4),)),

--- a/tests/sequence_test.py
+++ b/tests/sequence_test.py
@@ -101,8 +101,8 @@ def test_skipgrams():
                                          categorical=True)
     for couple in couples:
         assert couple[0] - couple[1] <= 3
-    for l in labels:
-        assert len(l) == 2
+    for label in labels:
+        assert len(label) == 2
 
 
 def test_remove_long_seq():


### PR DESCRIPTION

### Summary
Add option to handle non categorical labels when using NumpyArrayIterator/ImageDataGenerator.flow and a validation split. This is useful in non classification problems like pose estimation where the target Y is in a continuous space.

### Related Issues
#214 
### PR Overview

- [y] This PR requires new unit tests [y/n] (make sure tests are included)
- [y] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
