### PR TITLE
Fix `transform_matrix_offset_center`

### DIFF
--- a/keras_preprocessing/image/affine_transformations.py
+++ b/keras_preprocessing/image/affine_transformations.py
@@ -243,8 +243,8 @@ def random_brightness(x, brightness_range):
 
 
 def transform_matrix_offset_center(matrix, x, y):
-    o_x = float(x) / 2 + 0.5
-    o_y = float(y) / 2 + 0.5
+    o_x = float(x) / 2 - 0.5
+    o_y = float(y) / 2 - 0.5
     offset_matrix = np.array([[1, 0, o_x], [0, 1, o_y], [0, 0, 1]])
     reset_matrix = np.array([[1, 0, -o_x], [0, 1, -o_y], [0, 0, 1]])
     transform_matrix = np.dot(np.dot(offset_matrix, matrix), reset_matrix)

--- a/tests/image/affine_transformations_test.py
+++ b/tests/image/affine_transformations_test.py
@@ -15,16 +15,27 @@ def test_random_transforms():
 def test_deterministic_transform():
     x = np.ones((3, 3, 3))
     x_rotated = np.array([[[0., 0., 0.],
-                           [0., 0., 0.],
-                           [1., 1., 1.]],
-                          [[0., 0., 0.],
+                           [1., 1., 1.],
+                           [0., 0., 0.]],
+                          [[1., 1., 1.],
                            [1., 1., 1.],
                            [1., 1., 1.]],
                           [[0., 0., 0.],
-                           [0., 0., 0.],
-                           [1., 1., 1.]]])
+                           [1., 1., 1.],
+                           [0., 0., 0.]]])
     assert np.allclose(affine_transformations.apply_affine_transform(
         x, theta=45, channel_axis=2, fill_mode='constant'), x_rotated)
+
+
+def test_rotation_center():
+    x = np.array([[0, 1, 0],
+                  [0, 1, 0],
+                  [0, 1, 1]])[..., np.newaxis]
+    x_rotated = np.array([[0, 0, 0],
+                          [1, 1, 1],
+                          [1, 0, 0]])[..., np.newaxis]
+    assert np.allclose(affine_transformations.apply_affine_transform(
+        x, theta=90, channel_axis=2, fill_mode="constant"), x_rotated)
 
 
 def test_random_zoom():

--- a/tests/image/image_data_generator_test.py
+++ b/tests/image/image_data_generator_test.py
@@ -383,14 +383,14 @@ def test_deterministic_transform():
                        x[:, ::-1, :])
     x = np.ones((3, 3, 3))
     x_rotated = np.array([[[0., 0., 0.],
-                           [0., 0., 0.],
-                           [1., 1., 1.]],
-                          [[0., 0., 0.],
+                           [1., 1., 1.],
+                           [0., 0., 0.]],
+                          [[1., 1., 1.],
                            [1., 1., 1.],
                            [1., 1., 1.]],
                           [[0., 0., 0.],
-                           [0., 0., 0.],
-                           [1., 1., 1.]]])
+                           [1., 1., 1.],
+                           [0., 0., 0.]]])
     assert np.allclose(generator.apply_transform(x, {'theta': 45}),
                        x_rotated)
 


### PR DESCRIPTION
### Summary

Fix the axis of rotation, which has been shifted 1px from the correct location.

### Related Issues

### PR Overview

- [x] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
