### PR TITLE
Concatenate raw output in dataframe generator together into on array

### DIFF
--- a/keras_preprocessing/image/dataframe_iterator.py
+++ b/keras_preprocessing/image/dataframe_iterator.py
@@ -149,7 +149,7 @@ class DataFrameIterator(BatchFromFilesMixin, Iterator):
         if class_mode == "multi_output":
             self._targets = [np.array(df[col].tolist()) for col in y_col]
         if class_mode == "raw":
-            self._targets = df[y_col].values
+            self._targets = np.stack(df[y_col].values, 0)
         self.samples = len(self.filenames)
         validated_string = 'validated' if validate_filenames else 'non-validated'
         if class_mode in ["input", "multi_output", "raw", None]:

--- a/tests/image/dataframe_iterator_test.py
+++ b/tests/image/dataframe_iterator_test.py
@@ -397,6 +397,7 @@ def test_dataframe_iterator_class_mode_raw(all_test_images, tmpdir):
     assert batch_y.shape == (3, 5, 7)
     df_output_2d = np.stack(df['output_2d'].values[:3], 0)
     assert np.array_equal(batch_y, df_output_2d)
+    
 
 @pytest.mark.parametrize('validation_split,num_training', [
     (0.25, 18),

--- a/tests/image/dataframe_iterator_test.py
+++ b/tests/image/dataframe_iterator_test.py
@@ -360,7 +360,8 @@ def test_dataframe_iterator_class_mode_raw(all_test_images, tmpdir):
     # case for 1D output
     df = pd.DataFrame({"filename": filenames}).assign(
         output_0=np.random.uniform(size=len(filenames)),
-        output_1=np.random.uniform(size=len(filenames))
+        output_1=np.random.uniform(size=len(filenames)),
+        output_2d=[np.random.uniform(size=(5, 7) for _ in filenames]
     )
     df_iterator = image_data_generator.ImageDataGenerator().flow_from_dataframe(
         df, y_col='output_0', directory=str(tmpdir),
@@ -384,7 +385,18 @@ def test_dataframe_iterator_class_mode_raw(all_test_images, tmpdir):
     assert batch_y.shape == (3, 2)
     assert np.array_equal(batch_y,
                           df[['output_0', 'output_1']].values[:3])
-
+    # case with a 2D output from one column
+    df_iterator = image_data_generator.ImageDataGenerator().flow_from_dataframe(
+        df, y_col='output_2d', directory=str(tmpdir),
+        batch_size=3, shuffle=False, class_mode='raw'
+    )
+    batch_x, batch_y = next(df_iterator)
+    assert isinstance(batch_x, np.ndarray)
+    assert len(batch_x.shape) == 4
+    assert isinstance(batch_y, np.ndarray)
+    assert batch_y.shape == (3, 5, 7)
+    assert np.array_equal(batch_y,
+                          np.stack(df['output_2d'].values[:3], 0))
 
 @pytest.mark.parametrize('validation_split,num_training', [
     (0.25, 18),

--- a/tests/image/dataframe_iterator_test.py
+++ b/tests/image/dataframe_iterator_test.py
@@ -361,7 +361,7 @@ def test_dataframe_iterator_class_mode_raw(all_test_images, tmpdir):
     df = pd.DataFrame({"filename": filenames}).assign(
         output_0=np.random.uniform(size=len(filenames)),
         output_1=np.random.uniform(size=len(filenames)),
-        output_2d=[np.random.uniform(size=(5, 7) for _ in filenames]
+        output_2d=[np.random.uniform(size=(5, 7)) for _ in filenames]
     )
     df_iterator = image_data_generator.ImageDataGenerator().flow_from_dataframe(
         df, y_col='output_0', directory=str(tmpdir),
@@ -395,8 +395,8 @@ def test_dataframe_iterator_class_mode_raw(all_test_images, tmpdir):
     assert len(batch_x.shape) == 4
     assert isinstance(batch_y, np.ndarray)
     assert batch_y.shape == (3, 5, 7)
-    assert np.array_equal(batch_y,
-                          np.stack(df['output_2d'].values[:3], 0))
+    df_output_2d = np.stack(df['output_2d'].values[:3], 0)
+    assert np.array_equal(batch_y, df_output_2d)
 
 @pytest.mark.parametrize('validation_split,num_training', [
     (0.25, 18),

--- a/tests/image/dataframe_iterator_test.py
+++ b/tests/image/dataframe_iterator_test.py
@@ -397,7 +397,7 @@ def test_dataframe_iterator_class_mode_raw(all_test_images, tmpdir):
     assert batch_y.shape == (3, 5, 7)
     df_output_2d = np.stack(df['output_2d'].values[:3], 0)
     assert np.array_equal(batch_y, df_output_2d)
-    
+
 
 @pytest.mark.parametrize('validation_split,num_training', [
     (0.25, 18),


### PR DESCRIPTION
### Summary

Concatenate the output from a `raw` dataframe column together into an array.

### Related Issues
- closes #231

### PR Overview

- [x] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
