### PR TITLE
Add functionality  to read 32-bit images

### DIFF
--- a/keras_preprocessing/image/utils.py
+++ b/keras_preprocessing/image/utils.py
@@ -282,14 +282,6 @@ def array_to_img(x, data_format='channels_last', scale=True, dtype='float32'):
         raise ValueError('Unsupported channel number: %s' % (x.shape[2],))
 
 
-def _scale_img(x, lower_bound, upper_bound):
-    x = x + max(-np.min(x), 0)
-    x_max = np.max(x)
-    if x_max != 0:
-        x /= x_max
-    return x * (upper_bound - lower_bound) + lower_bound
-
-
 def img_to_array(img, data_format='channels_last', dtype='float32'):
     """Converts a PIL Image instance to a Numpy array.
 

--- a/keras_preprocessing/image/utils.py
+++ b/keras_preprocessing/image/utils.py
@@ -111,7 +111,9 @@ def load_img(path, grayscale=False, color_mode='rgb', target_size=None,
                           'The use of `load_img` requires PIL.')
     img = pil_image.open(path)
     if color_mode == 'grayscale':
-        if img.mode not in ('L', 'I'):  # 8-bit and 32-bit signed integer pixels
+        # if image is not already an 8-bit, 16-bit or 32-bit grayscale image
+        # convert it to an 8-bit grayscale image.
+        if img.mode not in ('L', 'I;16', 'I'):
             img = img.convert('L')
     elif color_mode == 'rgba':
         if img.mode != 'RGBA':

--- a/tests/image/directory_iterator_test.py
+++ b/tests/image/directory_iterator_test.py
@@ -113,7 +113,7 @@ def test_directory_iterator(all_test_images, tmpdir):
                                             color_mode='rgb',
                                             batch_size=3,
                                             class_mode='categorical')
-    assert len(dir_seq) == np.ceil(count / 3)
+    assert len(dir_seq) == np.ceil(count / 3.)
     x1, y1 = dir_seq[1]
     assert x1.shape == (3, 26, 26, 3)
     assert y1.shape == (3, num_classes)

--- a/tests/image/directory_iterator_test.py
+++ b/tests/image/directory_iterator_test.py
@@ -34,14 +34,17 @@ def all_test_images():
         im = Image.fromarray(imarray.astype('uint8').squeeze()).convert('L')
         gray_images.append(im)
         # 16-bit grayscale
-        imarray = np.array(np.random.randint(-2147483648, 2147483647, (img_w, img_h)))
+        imarray = np.array(
+            np.random.randint(-2147483648, 2147483647, (img_w, img_h))
+        )
         im = Image.fromarray(imarray.astype('uint16'))
         gray_images_16bit.append(im)
         # 32-bit grayscale
         im = Image.fromarray(imarray.astype('uint32'))
         gray_images_32bit.append(im)
 
-    return [rgb_images, rgba_images, gray_images, gray_images_16bit, gray_images_32bit]
+    return [rgb_images, rgba_images,
+            gray_images, gray_images_16bit, gray_images_32bit]
 
 
 def test_directory_iterator(all_test_images, tmpdir):

--- a/tests/image/directory_iterator_test.py
+++ b/tests/image/directory_iterator_test.py
@@ -16,23 +16,32 @@ def all_test_images():
     rgb_images = []
     rgba_images = []
     gray_images = []
+    gray_images_16bit = []
+    gray_images_32bit = []
     for n in range(8):
         bias = np.random.rand(img_w, img_h, 1) * 64
         variance = np.random.rand(img_w, img_h, 1) * (255 - 64)
+        # RGB
         imarray = np.random.rand(img_w, img_h, 3) * variance + bias
         im = Image.fromarray(imarray.astype('uint8')).convert('RGB')
         rgb_images.append(im)
-
+        # RGBA
         imarray = np.random.rand(img_w, img_h, 4) * variance + bias
         im = Image.fromarray(imarray.astype('uint8')).convert('RGBA')
         rgba_images.append(im)
-
+        # 8-bit grayscale
         imarray = np.random.rand(img_w, img_h, 1) * variance + bias
-        im = Image.fromarray(
-            imarray.astype('uint8').squeeze()).convert('L')
+        im = Image.fromarray(imarray.astype('uint8').squeeze()).convert('L')
         gray_images.append(im)
+        # 16-bit grayscale
+        imarray = np.array(np.random.randint(-2147483648, 2147483647, (img_w, img_h)))
+        im = Image.fromarray(imarray.astype('uint16'))
+        gray_images_16bit.append(im)
+        # 32-bit grayscale
+        im = Image.fromarray(imarray.astype('uint32'))
+        gray_images_32bit.append(im)
 
-    return [rgb_images, rgba_images, gray_images]
+    return [rgb_images, rgba_images, gray_images, gray_images_16bit, gray_images_32bit]
 
 
 def test_directory_iterator(all_test_images, tmpdir):
@@ -109,7 +118,7 @@ def test_directory_iterator(all_test_images, tmpdir):
     assert (x1 == 0).all()
 
     with pytest.raises(ValueError):
-        x1, y1 = dir_seq[9]
+        x1, y1 = dir_seq[14]  # there are 40 images and batch size is 3
 
 
 def test_directory_iterator_class_mode_input(all_test_images, tmpdir):
@@ -140,9 +149,9 @@ def test_directory_iterator_class_mode_input(all_test_images, tmpdir):
 
 
 @pytest.mark.parametrize('validation_split,num_training', [
-    (0.25, 18),
-    (0.50, 12),
-    (0.75, 6),
+    (0.25, 30),
+    (0.50, 20),
+    (0.75, 10),
 ])
 def test_directory_iterator_with_validation_split(all_test_images,
                                                   validation_split,

--- a/tests/image/utils_test.py
+++ b/tests/image/utils_test.py
@@ -20,6 +20,8 @@ def test_validate_filename(tmpdir):
 def test_load_img(tmpdir):
     filename_rgb = str(tmpdir / 'rgb_utils.png')
     filename_rgba = str(tmpdir / 'rgba_utils.png')
+    filename_grayscale_8bit = str(tmpdir / 'grayscale_8bit_utils.png')
+    filename_grayscale_32bit = str(tmpdir / 'grayscale_32bit_utils.tiff')
 
     original_rgb_array = np.array(255 * np.random.rand(100, 100, 3),
                                   dtype=np.uint8)
@@ -30,6 +32,19 @@ def test_load_img(tmpdir):
                                    dtype=np.uint8)
     original_rgba = utils.array_to_img(original_rgba_array, scale=False)
     original_rgba.save(filename_rgba)
+
+    original_grayscale_8bit_array = np.array(255 * np.random.rand(100, 100, 1),
+                                             dtype=np.uint8)
+    original_grayscale_8bit = utils.array_to_img(original_grayscale_8bit_array,
+                                                 scale=False)
+    original_grayscale_8bit.save(filename_grayscale_8bit)
+
+    original_grayscale_32bit_array = np.array(
+        np.random.randint(-2147483648, 2147483647, (100, 100, 1)), dtype=np.int32
+    )
+    original_grayscale_32bit = utils.array_to_img(original_grayscale_32bit_array,
+                                                  scale=False, dtype='int32')
+    original_grayscale_32bit.save(filename_grayscale_32bit)
 
     # Test that loaded image is exactly equal to original.
 
@@ -47,6 +62,19 @@ def test_load_img(tmpdir):
     loaded_im_array = utils.img_to_array(loaded_im)
     assert loaded_im_array.shape == (original_rgb_array.shape[0],
                                      original_rgb_array.shape[1], 1)
+
+    loaded_im = utils.load_img(filename_grayscale_8bit, color_mode='grayscale')
+    loaded_im_array = utils.img_to_array(loaded_im)
+    assert loaded_im_array.shape == original_grayscale_8bit_array.shape
+    assert np.all(loaded_im_array == original_grayscale_8bit_array)
+
+    loaded_im = utils.load_img(filename_grayscale_32bit, color_mode='grayscale')
+    loaded_im_array = utils.img_to_array(loaded_im, dtype='int32')
+    assert loaded_im_array.shape == original_grayscale_32bit_array.shape
+    assert np.all(loaded_im_array == original_grayscale_32bit_array)
+    # test casting int32 image to float32
+    loaded_im_array = utils.img_to_array(loaded_im)
+    assert np.allclose(loaded_im_array, original_grayscale_32bit_array)
 
     # Test that nothing is changed when target size is equal to original.
 
@@ -67,6 +95,18 @@ def test_load_img(tmpdir):
     assert loaded_im_array.shape == (original_rgba_array.shape[0],
                                      original_rgba_array.shape[1], 1)
 
+    loaded_im = utils.load_img(filename_grayscale_8bit, color_mode='grayscale',
+                               target_size=(100, 100))
+    loaded_im_array = utils.img_to_array(loaded_im)
+    assert loaded_im_array.shape == original_grayscale_8bit_array.shape
+    assert np.all(loaded_im_array == original_grayscale_8bit_array)
+
+    loaded_im = utils.load_img(filename_grayscale_32bit, color_mode='grayscale',
+                               target_size=(100, 100))
+    loaded_im_array = utils.img_to_array(loaded_im, dtype='int32')
+    assert loaded_im_array.shape == original_grayscale_32bit_array.shape
+    assert np.all(loaded_im_array == original_grayscale_32bit_array)
+
     # Test down-sampling with bilinear interpolation.
 
     loaded_im = utils.load_img(filename_rgb, target_size=(25, 25))
@@ -83,6 +123,16 @@ def test_load_img(tmpdir):
     loaded_im_array = utils.img_to_array(loaded_im)
     assert loaded_im_array.shape == (25, 25, 1)
 
+    loaded_im = utils.load_img(filename_grayscale_8bit, color_mode='grayscale',
+                               target_size=(25, 25))
+    loaded_im_array = utils.img_to_array(loaded_im)
+    assert loaded_im_array.shape == (25, 25, 1)
+
+    loaded_im = utils.load_img(filename_grayscale_32bit, color_mode='grayscale',
+                               target_size=(25, 25))
+    loaded_im_array = utils.img_to_array(loaded_im, dtype='int32')
+    assert loaded_im_array.shape == (25, 25, 1)
+
     # Test down-sampling with nearest neighbor interpolation.
 
     loaded_im_nearest = utils.load_img(filename_rgb, target_size=(25, 25),
@@ -97,6 +147,16 @@ def test_load_img(tmpdir):
     loaded_im_array_nearest = utils.img_to_array(loaded_im_nearest)
     assert loaded_im_array_nearest.shape == (25, 25, 4)
     assert np.any(loaded_im_array_nearest != loaded_im_array)
+
+    loaded_im = utils.load_img(filename_grayscale_8bit, color_mode='grayscale',
+                               target_size=(25, 25), interpolation="nearest")
+    loaded_im_array = utils.img_to_array(loaded_im)
+    assert loaded_im_array.shape == (25, 25, 1)
+
+    loaded_im = utils.load_img(filename_grayscale_32bit, color_mode='grayscale',
+                               target_size=(25, 25), interpolation="nearest")
+    loaded_im_array = utils.img_to_array(loaded_im, dtype='int32')
+    assert loaded_im_array.shape == (25, 25, 1)
 
     # Check that exception is raised if interpolation not supported.
 
@@ -150,6 +210,17 @@ def test_array_to_img_and_img_to_array():
     x = utils.img_to_array(img, data_format='channels_first')
     assert x.shape == (1, height, width)
 
+    # grayscale 32-bit signed integer
+    x = np.array(
+        np.random.randint(-2147483648, 2147483647, (1, height, width)),
+        dtype=np.int32
+    )
+    img = utils.array_to_img(x, data_format='channels_first')
+    assert img.size == (width, height)
+
+    x = utils.img_to_array(img, data_format='channels_first')
+    assert x.shape == (1, height, width)
+
     # Test tf data format
     # Test RGB 3D
     x = np.random.random((height, width, 3))
@@ -169,6 +240,17 @@ def test_array_to_img_and_img_to_array():
 
     # Test 2D
     x = np.random.random((height, width, 1))
+    img = utils.array_to_img(x, data_format='channels_last')
+    assert img.size == (width, height)
+
+    x = utils.img_to_array(img, data_format='channels_last')
+    assert x.shape == (height, width, 1)
+
+    # grayscale 32-bit signed integer
+    x = np.array(
+        np.random.randint(-2147483648, 2147483647, (height, width, 1)),
+        dtype=np.int32
+    )
     img = utils.array_to_img(x, data_format='channels_last')
     assert img.size == (width, height)
 

--- a/tests/image/utils_test.py
+++ b/tests/image/utils_test.py
@@ -21,6 +21,7 @@ def test_load_img(tmpdir):
     filename_rgb = str(tmpdir / 'rgb_utils.png')
     filename_rgba = str(tmpdir / 'rgba_utils.png')
     filename_grayscale_8bit = str(tmpdir / 'grayscale_8bit_utils.png')
+    filename_grayscale_16bit = str(tmpdir / 'grayscale_16bit_utils.tiff')
     filename_grayscale_32bit = str(tmpdir / 'grayscale_32bit_utils.tiff')
 
     original_rgb_array = np.array(255 * np.random.rand(100, 100, 3),
@@ -38,6 +39,13 @@ def test_load_img(tmpdir):
     original_grayscale_8bit = utils.array_to_img(original_grayscale_8bit_array,
                                                  scale=False)
     original_grayscale_8bit.save(filename_grayscale_8bit)
+
+    original_grayscale_16bit_array = np.array(
+        np.random.randint(-2147483648, 2147483647, (100, 100, 1)), dtype=np.int16
+    )
+    original_grayscale_16bit = utils.array_to_img(original_grayscale_16bit_array,
+                                                  scale=False, dtype='int16')
+    original_grayscale_16bit.save(filename_grayscale_16bit)
 
     original_grayscale_32bit_array = np.array(
         np.random.randint(-2147483648, 2147483647, (100, 100, 1)), dtype=np.int32
@@ -67,6 +75,14 @@ def test_load_img(tmpdir):
     loaded_im_array = utils.img_to_array(loaded_im)
     assert loaded_im_array.shape == original_grayscale_8bit_array.shape
     assert np.all(loaded_im_array == original_grayscale_8bit_array)
+
+    loaded_im = utils.load_img(filename_grayscale_16bit, color_mode='grayscale')
+    loaded_im_array = utils.img_to_array(loaded_im, dtype='int16')
+    assert loaded_im_array.shape == original_grayscale_16bit_array.shape
+    assert np.all(loaded_im_array == original_grayscale_16bit_array)
+    # test casting int16 image to float32
+    loaded_im_array = utils.img_to_array(loaded_im)
+    assert np.allclose(loaded_im_array, original_grayscale_16bit_array)
 
     loaded_im = utils.load_img(filename_grayscale_32bit, color_mode='grayscale')
     loaded_im_array = utils.img_to_array(loaded_im, dtype='int32')
@@ -101,6 +117,12 @@ def test_load_img(tmpdir):
     assert loaded_im_array.shape == original_grayscale_8bit_array.shape
     assert np.all(loaded_im_array == original_grayscale_8bit_array)
 
+    loaded_im = utils.load_img(filename_grayscale_16bit, color_mode='grayscale',
+                               target_size=(100, 100))
+    loaded_im_array = utils.img_to_array(loaded_im, dtype='int16')
+    assert loaded_im_array.shape == original_grayscale_16bit_array.shape
+    assert np.all(loaded_im_array == original_grayscale_16bit_array)
+
     loaded_im = utils.load_img(filename_grayscale_32bit, color_mode='grayscale',
                                target_size=(100, 100))
     loaded_im_array = utils.img_to_array(loaded_im, dtype='int32')
@@ -128,6 +150,11 @@ def test_load_img(tmpdir):
     loaded_im_array = utils.img_to_array(loaded_im)
     assert loaded_im_array.shape == (25, 25, 1)
 
+    loaded_im = utils.load_img(filename_grayscale_16bit, color_mode='grayscale',
+                               target_size=(25, 25))
+    loaded_im_array = utils.img_to_array(loaded_im, dtype='int16')
+    assert loaded_im_array.shape == (25, 25, 1)
+
     loaded_im = utils.load_img(filename_grayscale_32bit, color_mode='grayscale',
                                target_size=(25, 25))
     loaded_im_array = utils.img_to_array(loaded_im, dtype='int32')
@@ -151,6 +178,11 @@ def test_load_img(tmpdir):
     loaded_im = utils.load_img(filename_grayscale_8bit, color_mode='grayscale',
                                target_size=(25, 25), interpolation="nearest")
     loaded_im_array = utils.img_to_array(loaded_im)
+    assert loaded_im_array.shape == (25, 25, 1)
+
+    loaded_im = utils.load_img(filename_grayscale_16bit, color_mode='grayscale',
+                               target_size=(25, 25), interpolation="nearest")
+    loaded_im_array = utils.img_to_array(loaded_im, dtype='int16')
     assert loaded_im_array.shape == (25, 25, 1)
 
     loaded_im = utils.load_img(filename_grayscale_32bit, color_mode='grayscale',
@@ -240,6 +272,17 @@ def test_array_to_img_and_img_to_array():
 
     # Test 2D
     x = np.random.random((height, width, 1))
+    img = utils.array_to_img(x, data_format='channels_last')
+    assert img.size == (width, height)
+
+    x = utils.img_to_array(img, data_format='channels_last')
+    assert x.shape == (height, width, 1)
+
+    # grayscale 16-bit signed integer
+    x = np.array(
+        np.random.randint(-2147483648, 2147483647, (height, width, 1)),
+        dtype=np.int16
+    )
     img = utils.array_to_img(x, data_format='channels_last')
     assert img.size == (width, height)
 


### PR DESCRIPTION
### Summary

This PR adds the functionality to read 32-bit images (32-bit signed  integer pixel values) without losing information. This is specifically important for medical images as a great deal of information is being lost on the conversion to 8-bit.

The `load_img` function only affects and leaves 32-bit signed integer format ("I" for [PIL modes](https://pillow.readthedocs.io/en/5.1.x/handbook/concepts.html#modes)) untouched.

The `array_to_img` function now returns a 32-bit signed integer ("I" mode in PIL) if the array has a single channel and the maximum value of any pixel exceeds 255.

One thing to note is that if `array_to_img` is executed with the argument `scale=True` then even if the array is in 32-bit format, the array will be normalized to 8-bit and return an 8-bit PIL image (mode "L").

This PR has tests for 32-bit but I also added for grayscale 8-bit specifically.

### Related Issues
Closes #239 

### PR Overview

- [ y] This PR requires new unit tests [y/n] (make sure tests are included)
- [y ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y ] This PR is backwards compatible [y/n]
- [n ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
