### PR TITLE
Remove version pinning of tensorflow in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(name='Keras_Preprocessing',
       extras_require={
           'tests': ['pandas',
                     'Pillow' if sys.version_info >= (3, 0) else 'pillow',
-                    'tensorflow==1.7',  # CPU version <dummy>
+                    'tensorflow',  # CPU version
                     'keras',
                     'pytest',
                     'pytest-xdist',

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(name='Keras_Preprocessing',
       extras_require={
           'tests': ['pandas',
                     'Pillow' if sys.version_info >= (3, 0) else 'pillow',
-                    'tensorflow==1.7',  # CPU version
+                    'tensorflow==1.7',  # CPU version <dummy>
                     'keras',
                     'pytest',
                     'pytest-xdist',


### PR DESCRIPTION
### Summary
Remove pinning tensorflow to a version. According to the [](https://www.tensorflow.org/install) the CPU stable version does not need any version pinning. 

As a side effect is making the CI fail.
### PR Overview

- [ n] This PR requires new unit tests [y/n] (make sure tests are included)
- [n ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y ] This PR is backwards compatible [y/n]
- [ n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
