### PR TITLE
Remove scaling of images when saving to disk

### DIFF
--- a/keras_preprocessing/image/iterator.py
+++ b/keras_preprocessing/image/iterator.py
@@ -241,7 +241,7 @@ class BatchFromFilesMixin():
         # optionally save augmented images to disk for debugging purposes
         if self.save_to_dir:
             for i, j in enumerate(index_array):
-                img = array_to_img(batch_x[i], self.data_format, scale=True)
+                img = array_to_img(batch_x[i], self.data_format, scale=False)
                 fname = '{prefix}_{index}_{hash}.{format}'.format(
                     prefix=self.save_prefix,
                     index=j,

--- a/keras_preprocessing/image/numpy_array_iterator.py
+++ b/keras_preprocessing/image/numpy_array_iterator.py
@@ -156,7 +156,7 @@ class NumpyArrayIterator(Iterator):
 
         if self.save_to_dir:
             for i, j in enumerate(index_array):
-                img = array_to_img(batch_x[i], self.data_format, scale=True)
+                img = array_to_img(batch_x[i], self.data_format, scale=False)
                 fname = '{prefix}_{index}_{hash}.{format}'.format(
                     prefix=self.save_prefix,
                     index=j,


### PR DESCRIPTION
### Summary
When using `ImageDataGenerator` methods and saving to disk, the images saved to disk are scaled and do not present an accurate representation of what the generator is actually using as samples in the produced batches.

Current behavior:
```
import numpy as np
from datetime import datetime
from glob import glob

from keras_preprocessing.image import ImageDataGenerator
from keras_preprocessing.image.utils import load_img, array_to_img, img_to_array

x = np.random.randint(20, 30, size=(1, 100, 100 , 1))
img = array_to_img(x[0], scale=False)
prefix = str(datetime.now())
batch_gen = ImageDataGenerator().flow(x,
                                      batch_size=1,
                                      save_to_dir='.',
                                      save_prefix=prefix)
x = next(batch_gen)

img2 = load_img(glob('{}*'.format(prefix))[0], color_mode='grayscale')
x2 = img_to_array(img2)
np.all(x[0] == x2)
>>> False
```
Visually comparing the images also yield differences because of the scaling.

![Selection_031](https://user-images.githubusercontent.com/16643700/65724485-caa22280-e0b0-11e9-8cab-ed1e09259372.png)

This is confusing for the user if the user wants to have a visual check. This will be specially important now that we can have batches with grayscale images of 16-bit and 32-bit pixel values, when rescaling they become 8-bit and look extremely different.

NOTE: I have the feeling that the scaling logic itself is wrong but I will address that in another issue/PR

### Related Issues
Closes #221 

### PR Overview

- [n] This PR requires new unit tests [y/n] (make sure tests are included)
- [n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
