### PR TITLE
Add inter_batch_stride param to TimeSeriesGenerator

### DIFF
--- a/keras_preprocessing/sequence.py
+++ b/keras_preprocessing/sequence.py
@@ -393,8 +393,8 @@ class TimeseriesGenerator(object):
                  end_index=None,
                  shuffle=False,
                  reverse=False,
-                 inter_batch_stride=None,
-                 batch_size=128):
+                 batch_size=128,
+                 inter_batch_stride=None):
 
         if len(data) != len(targets):
             raise ValueError('Data and targets have to be' +
@@ -478,12 +478,12 @@ class TimeseriesGenerator(object):
             'length': self.length,
             'sampling_rate': self.sampling_rate,
             'stride': self.stride,
-            'inter_batch_stride': self.inter_batch_stride,
             'start_index': self.start_index,
             'end_index': self.end_index,
             'shuffle': self.shuffle,
             'reverse': self.reverse,
-            'batch_size': self.batch_size
+            'batch_size': self.batch_size,
+            'inter_batch_stride': self.inter_batch_stride
         }
 
     def to_json(self, **kwargs):

--- a/tests/sequence_test.py
+++ b/tests/sequence_test.py
@@ -213,6 +213,28 @@ def test_TimeseriesGenerator():
     assert (np.allclose(data_gen[0][1],
                         np.array([[20], [21]])))
 
+    data_gen = sequence.TimeseriesGenerator(data, targets,
+                                            length=5, sampling_rate=1,
+                                            batch_size=4, stride=2,
+                                            inter_batch_stride=5)
+    assert len(data_gen) == 9
+
+    assert np.allclose(data_gen[0][0],
+                       np.array([[[0], [1], [2], [3], [4]],
+                                 [[2], [3], [4], [5], [6]],
+                                 [[4], [5], [6], [7], [8]],
+                                 [[6], [7], [8], [9], [10]]]))
+    assert np.allclose(data_gen[0][1],
+                       np.array([[5], [7], [9], [11]]))
+
+    assert np.allclose(data_gen[1][0],
+                       np.array([[[5], [6],  [7],  [8],  [9]],
+                                 [[7], [8],  [9], [10], [11]],
+                                 [[9], [10], [11], [12], [13]],
+                                 [[11], [12], [13], [14], [15]]]))
+    assert np.allclose(data_gen[1][1],
+                       np.array([[10], [12], [14], [16]]))
+
     data = np.array([np.random.random_sample((1, 2, 3, 4)) for i in range(50)])
     targets = np.array([np.random.random_sample((3, 2, 1)) for i in range(50)])
     data_gen = sequence.TimeseriesGenerator(data, targets,


### PR DESCRIPTION
### Summary

Grant explicit control for inter-batch sample ordering in TimeSeriesGenerator.
This change is backwards compatible.

### Related Issues

See this [stackoverflow](https://stackoverflow.com/questions/58276337/proper-way-to-feed-time-series-data-to-stateful-lstm) question for background.

### PR Overview

The original TimeSeriesGenerator emits batches where the first sample is
a stride ahead of the previous batch's last sample. Many times more
control is required (especially if feeding to a stateful RNN).

The inter_batch_stride option allows user to explicitly specify the
inter-batch stride relationships.  If this option is None (or not
supplied), the original behavior is maintained.

- [y] This PR requires new unit tests [y/n] (make sure tests are included)
- [y] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [y] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
