### PR TITLE
doc: explain mechanism of validation data split of flow_from_directory

### DIFF
--- a/keras_preprocessing/image/image_data_generator.py
+++ b/keras_preprocessing/image/image_data_generator.py
@@ -504,7 +504,8 @@ class ImageDataGenerator(object):
             follow_links: Whether to follow symlinks inside
                 class subdirectories (default: False).
             subset: Subset of data (`"training"` or `"validation"`) if
-                `validation_split` is set in `ImageDataGenerator`.
+                `validation_split` is set in `ImageDataGenerator`. Files
+                will be split after sorting in alphanumeric order.
             interpolation: Interpolation method used to
                 resample the image if the
                 target size is different from that of the loaded image.


### PR DESCRIPTION
### Summary

This PR proposes to clarify the mechanism of creation validation set generation in function `flow_from_directory` when validate_split option is used. This may be potentially important when the image files in the directory have meaningful names (for example, encode particular instance of the objects). One can imagine the following organisation of files:
```
Cats/
    balinese1.jpg
    balinese2.jpg
    siamese1.jpg
    siamese2.jpg
Dogs/
    Shepard1.jpg
    Shepard2.jpg
    Terrier2.jpg
```

In such a setting validation set might get all siamese cats and terrier dogs, while the training set might get balinese cats and shepard dogs. This will heavilly affect validation metrics.


### Related Issues

### PR Overview

- [n ] This PR requires new unit tests [y/n] (make sure tests are included)
- [y] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
