### PR TITLE
can now disable augmentation

### DIFF
--- a/keras_preprocessing/image/dataframe_iterator.py
+++ b/keras_preprocessing/image/dataframe_iterator.py
@@ -74,6 +74,9 @@ class DataFrameIterator(BatchFromFilesMixin, Iterator):
             (if `save_to_dir` is set).
         subset: Subset of data (`"training"` or `"validation"`) if
             validation_split is set in ImageDataGenerator.
+        apply_augmentation: Boolean, can be set to False to disable
+            data augmentation, e.g. for the validation subset.
+            Standardization is still applied.
         interpolation: Interpolation method used to resample the image if the
             target size is different from that of the loaded image.
             Supported methods are "nearest", "bilinear", and "bicubic".
@@ -108,6 +111,7 @@ class DataFrameIterator(BatchFromFilesMixin, Iterator):
                  save_prefix='',
                  save_format='png',
                  subset=None,
+                 apply_augmentation=True,
                  interpolation='nearest',
                  dtype='float32',
                  validate_filenames=True):
@@ -120,6 +124,7 @@ class DataFrameIterator(BatchFromFilesMixin, Iterator):
                                                             save_prefix,
                                                             save_format,
                                                             subset,
+                                                            apply_augmentation,
                                                             interpolation)
         df = dataframe.copy()
         self.directory = directory or ''

--- a/keras_preprocessing/image/directory_iterator.py
+++ b/keras_preprocessing/image/directory_iterator.py
@@ -54,6 +54,9 @@ class DirectoryIterator(BatchFromFilesMixin, Iterator):
         follow_links: boolean,follow symbolic links to subdirectories
         subset: Subset of data (`"training"` or `"validation"`) if
             validation_split is set in ImageDataGenerator.
+        apply_augmentation: Boolean, can be set to False to disable
+            data augmentation, e.g. for the validation subset.
+            Standardization is still applied.
         interpolation: Interpolation method used to resample the image if the
             target size is different from that of the loaded image.
             Supported methods are "nearest", "bilinear", and "bicubic".
@@ -80,6 +83,7 @@ class DirectoryIterator(BatchFromFilesMixin, Iterator):
                  save_format='png',
                  follow_links=False,
                  subset=None,
+                 apply_augmentation=True,
                  interpolation='nearest',
                  dtype='float32'):
         super(DirectoryIterator, self).set_processing_attrs(image_data_generator,
@@ -90,6 +94,7 @@ class DirectoryIterator(BatchFromFilesMixin, Iterator):
                                                             save_prefix,
                                                             save_format,
                                                             subset,
+                                                            apply_augmentation,
                                                             interpolation)
         self.directory = directory
         self.classes = classes

--- a/keras_preprocessing/image/image_data_generator.py
+++ b/keras_preprocessing/image/image_data_generator.py
@@ -374,7 +374,8 @@ class ImageDataGenerator(object):
              save_to_dir=None,
              save_prefix='',
              save_format='png',
-             subset=None):
+             subset=None,
+             apply_augmentation=True):
         """Takes data & label arrays, generates batches of augmented data.
 
         # Arguments
@@ -429,7 +430,8 @@ class ImageDataGenerator(object):
             save_to_dir=save_to_dir,
             save_prefix=save_prefix,
             save_format=save_format,
-            subset=subset
+            subset=subset,
+            apply_augmentation=apply_augmentation
         )
 
     def flow_from_directory(self,
@@ -446,6 +448,7 @@ class ImageDataGenerator(object):
                             save_format='png',
                             follow_links=False,
                             subset=None,
+                            apply_augmentation=True,
                             interpolation='nearest'):
         """Takes the path to a directory & generates batches of augmented data.
 
@@ -537,6 +540,7 @@ class ImageDataGenerator(object):
             save_format=save_format,
             follow_links=follow_links,
             subset=subset,
+            apply_augmentation=apply_augmentation,
             interpolation=interpolation
         )
 
@@ -557,6 +561,7 @@ class ImageDataGenerator(object):
                             save_prefix='',
                             save_format='png',
                             subset=None,
+                            apply_augmentation=True,
                             interpolation='nearest',
                             validate_filenames=True,
                             **kwargs):
@@ -679,6 +684,7 @@ class ImageDataGenerator(object):
             save_prefix=save_prefix,
             save_format=save_format,
             subset=subset,
+            apply_augmentation=apply_augmentation,
             interpolation=interpolation,
             validate_filenames=validate_filenames
         )

--- a/keras_preprocessing/image/iterator.py
+++ b/keras_preprocessing/image/iterator.py
@@ -142,6 +142,7 @@ class BatchFromFilesMixin():
                              save_prefix,
                              save_format,
                              subset,
+                             apply_augmentation,
                              interpolation):
         """Sets attributes to use later for processing files into a batch.
 
@@ -162,6 +163,9 @@ class BatchFromFilesMixin():
                 (if `save_to_dir` is set).
             subset: Subset of data (`"training"` or `"validation"`) if
                 validation_split is set in ImageDataGenerator.
+            apply_augmentation: Boolean, can be set to False to disable
+                data augmentation, e.g. for the validation subset.
+                Standardization is still applied.
             interpolation: Interpolation method used to resample the image if the
                 target size is different from that of the loaded image.
                 Supported methods are "nearest", "bilinear", and "bicubic".
@@ -209,6 +213,7 @@ class BatchFromFilesMixin():
             split = None
         self.split = split
         self.subset = subset
+        self.apply_augmentation = apply_augmentation
 
     def _get_batches_of_transformed_samples(self, index_array):
         """Gets a batch of transformed samples.
@@ -234,8 +239,9 @@ class BatchFromFilesMixin():
             if hasattr(img, 'close'):
                 img.close()
             if self.image_data_generator:
-                params = self.image_data_generator.get_random_transform(x.shape)
-                x = self.image_data_generator.apply_transform(x, params)
+                if self.apply_augmentation:
+                    params = self.image_data_generator.get_random_transform(x.shape)
+                    x = self.image_data_generator.apply_transform(x, params)
                 x = self.image_data_generator.standardize(x)
             batch_x[i] = x
         # optionally save augmented images to disk for debugging purposes

--- a/keras_preprocessing/image/numpy_array_iterator.py
+++ b/keras_preprocessing/image/numpy_array_iterator.py
@@ -39,6 +39,9 @@ class NumpyArrayIterator(Iterator):
             (if `save_to_dir` is set).
         subset: Subset of data (`"training"` or `"validation"`) if
             validation_split is set in ImageDataGenerator.
+        apply_augmentation: Boolean, can be set to False to disable
+            data augmentation, e.g. for the validation subset.
+            Standardization is still applied.
         dtype: Dtype to use for the generated arrays.
     """
 
@@ -55,6 +58,7 @@ class NumpyArrayIterator(Iterator):
                  save_prefix='',
                  save_format='png',
                  subset=None,
+                 apply_augmentation=True,
                  dtype='float32'):
         self.dtype = dtype
         if (type(x) is tuple) or (type(x) is list):
@@ -108,7 +112,7 @@ class NumpyArrayIterator(Iterator):
                 x_misc = [np.asarray(xx[split_idx:]) for xx in x_misc]
                 if y is not None:
                     y = y[split_idx:]
-
+        self.apply_augmentation = apply_augmentation
         self.x = np.asarray(x, dtype=self.dtype)
         self.x_misc = x_misc
         if self.x.ndim != 4:
@@ -148,9 +152,9 @@ class NumpyArrayIterator(Iterator):
                            dtype=self.dtype)
         for i, j in enumerate(index_array):
             x = self.x[j]
-            params = self.image_data_generator.get_random_transform(x.shape)
-            x = self.image_data_generator.apply_transform(
-                x.astype(self.dtype), params)
+            if self.apply_augmentation:
+                params = self.image_data_generator.get_random_transform(x.shape)
+                x = self.image_data_generator.apply_transform(x.astype(self.dtype), params)
             x = self.image_data_generator.standardize(x)
             batch_x[i] = x
 

--- a/keras_preprocessing/image/numpy_array_iterator.py
+++ b/keras_preprocessing/image/numpy_array_iterator.py
@@ -154,7 +154,8 @@ class NumpyArrayIterator(Iterator):
             x = self.x[j]
             if self.apply_augmentation:
                 params = self.image_data_generator.get_random_transform(x.shape)
-                x = self.image_data_generator.apply_transform(x.astype(self.dtype), params)
+                x = self.image_data_generator.apply_transform(x.astype(self.dtype),
+                                                              params)
             x = self.image_data_generator.standardize(x)
             batch_x[i] = x
 

--- a/tests/image/dataframe_iterator_test.py
+++ b/tests/image/dataframe_iterator_test.py
@@ -123,6 +123,22 @@ def test_dataframe_iterator(all_test_images, tmpdir):
     with pytest.raises(ValueError):
         x1, y1 = dir_seq[9]
 
+    # Test that augmentation can be disabled.
+    # other tests for possible values of apply_augmentation
+    # in directory_iterator_test.
+    generator = image_data_generator.ImageDataGenerator(
+        rotation_range=0.2,
+    )
+    dir_seq = generator.flow_from_dataframe(df, str(tmpdir),
+                                            target_size=(26, 26),
+                                            color_mode='rgb',
+                                            batch_size=3,
+                                            apply_augmentation=False,
+                                            class_mode='categorical')
+    x1, _ = dir_seq[0]
+    x2, _ = dir_seq[0]
+    assert np.array_equal(x1, x2)
+
 
 def test_dataframe_iterator_validate_filenames(all_test_images, tmpdir):
     # save the images in the paths

--- a/tests/image/directory_iterator_test.py
+++ b/tests/image/directory_iterator_test.py
@@ -131,7 +131,7 @@ def test_directory_iterator(all_test_images, tmpdir):
     batch_size = 4
     # augmentation not disabled
     seq = generator.flow_from_directory(
-        tmpdir,
+        str(tmpdir),
         target_size=(26, 26),
         color_mode='rgb',
         class_mode='categorical',
@@ -144,7 +144,7 @@ def test_directory_iterator(all_test_images, tmpdir):
     assert not np.array_equal(x1, x2)
     # augmentation not disabled
     seq = generator.flow_from_directory(
-        tmpdir,
+        str(tmpdir),
         target_size=(26, 26),
         color_mode='rgb',
         class_mode='categorical',
@@ -156,7 +156,7 @@ def test_directory_iterator(all_test_images, tmpdir):
     assert not np.array_equal(x1, x2)
     # augmentation disabled
     seq = generator.flow_from_directory(
-        tmpdir,
+        str(tmpdir),
         target_size=(26, 26),
         color_mode='rgb',
         class_mode='categorical',

--- a/tests/image/directory_iterator_test.py
+++ b/tests/image/directory_iterator_test.py
@@ -107,7 +107,8 @@ def test_directory_iterator(all_test_images, tmpdir):
 
     # Test usage as Sequence
     generator = image_data_generator.ImageDataGenerator(
-        preprocessing_function=preprocessing_function)
+        preprocessing_function=preprocessing_function
+    )
     dir_seq = generator.flow_from_directory(str(tmpdir),
                                             target_size=(26, 26),
                                             color_mode='rgb',
@@ -122,6 +123,50 @@ def test_directory_iterator(all_test_images, tmpdir):
 
     with pytest.raises(ValueError):
         x1, y1 = dir_seq[14]  # there are 40 images and batch size is 3
+
+    # Test that augmentation can be disabled
+    generator = image_data_generator.ImageDataGenerator(
+        rotation_range=0.2,
+    )
+    batch_size = 4
+    # augmentation not disabled
+    seq = generator.flow_from_directory(
+        tmpdir,
+        target_size=(26, 26),
+        color_mode='rgb',
+        class_mode='categorical',
+        apply_augmentation=True,
+        shuffle=False,
+        batch_size=batch_size, seed=123
+    )
+    x1, _ = seq[0]
+    x2, _ = seq[0]
+    assert not np.array_equal(x1, x2)
+    # augmentation not disabled
+    seq = generator.flow_from_directory(
+        tmpdir,
+        target_size=(26, 26),
+        color_mode='rgb',
+        class_mode='categorical',
+        shuffle=False,
+        batch_size=batch_size, seed=123
+    )
+    x1, _ = seq[0]
+    x2, _ = seq[0]
+    assert not np.array_equal(x1, x2)
+    # augmentation disabled
+    seq = generator.flow_from_directory(
+        tmpdir,
+        target_size=(26, 26),
+        color_mode='rgb',
+        class_mode='categorical',
+        apply_augmentation=False,
+        shuffle=False,
+        batch_size=batch_size, seed=123
+    )
+    x1, _ = seq[0]
+    x2, _ = seq[0]
+    assert np.array_equal(x1, x2)
 
 
 def test_directory_iterator_class_mode_input(all_test_images, tmpdir):

--- a/tests/image/image_data_generator_test.py
+++ b/tests/image/image_data_generator_test.py
@@ -286,6 +286,8 @@ def test_image_data_generator_flow(all_test_images, tmpdir):
             batch_size=3,
             shuffle=False
         )
+
+        # now using a generator without data augmentation
         generator = image_data_generator.ImageDataGenerator(validation_split=0.2)
         generator.flow(images, batch_size=3)
 
@@ -315,6 +317,41 @@ def test_image_data_generator_flow(all_test_images, tmpdir):
             shuffle=True, save_to_dir=str(tmpdir),
             batch_size=3, seed=123
         )
+
+        # Test that augmentation can be disabled
+        generator = image_data_generator.ImageDataGenerator(
+            rotation_range=0.2,
+        )
+        batch_size = 4
+        # augmentation not disabled
+        seq = generator.flow(
+            images,
+            np.arange(images.shape[0]),
+            apply_augmentation=True,
+            shuffle=False,
+            batch_size=batch_size, seed=123
+        )
+        x, _ = seq[0]
+        assert not np.array_equal(x, images[:batch_size])
+        # augmentation not disabled
+        seq = generator.flow(
+            images,
+            np.arange(images.shape[0]),
+            shuffle=False,
+            batch_size=batch_size, seed=123
+        )
+        x, _ = seq[0]
+        assert not np.array_equal(x, images[:batch_size])
+        # augmentation disabled
+        seq = generator.flow(
+            images,
+            np.arange(images.shape[0]),
+            apply_augmentation=False,
+            shuffle=False,
+            batch_size=batch_size, seed=123
+        )
+        x, _ = seq[0]
+        assert np.array_equal(x, images[:batch_size])
 
     # test order_interpolation
     labels = np.array([[2, 2, 0, 2, 2],


### PR DESCRIPTION
### Summary

Hi, this PR makes it possible to disable data augmentation. 

This feature can be needed for the validation subset for two reasons:

- Random data augmentation degrades the validation subset, which means that the true validation accuracy is in fact higher than the one currently obtained from keras. For instance, in machine learning challenges, the test dataset is not augmented. Also, in real life, we apply our models to datasets that are not augmented.  
- Due to augmentation, the validation subset changes at each epoch which leads to random fluctuations in the validation accuracy as a function of the epoch.

A new parameter has been added to the `flow` methods, `apply_augmentation`. This parameter is optional, and set to `True` by default, so that the current interface and behaviour is preserved. It can affect either the full set, the validation subset, or the training subset, depending on the subset argument. 

In issue #218  we discussed the possibility to introduce a parameter to disable augmentation for the validation set only. However, after a detailed look at the code, I concluded that it would be more logical to introduce this feature for both subsets in a generic way. 

The main reason for this decision is that a parameter like `disable_augmentation_for_validation` would have been rather weird, and more difficult to explain in the documentation to the user.  

This has the additional advantage of making it possible to disable augmentation completely for the training subset as well with a single line, e.g. when comparing augmentation vs no augmentation. 

Please let me know what you think, I'll be happy to iterate on this.

Thanks!

### Related Issues

#218 

### PR Overview

- [ y] This PR requires new unit tests [y/n] (make sure tests are included)
- [ y] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [ y] This PR is backwards compatible [y/n]
- [ n] This PR changes the current API **(I assume that new optional parameters are not considered a change to the API, but that's obviously your call)**