### PR TITLE
Rescale with featurewise normalization bug fix

### DIFF
--- a/keras_preprocessing/image/image_data_generator.py
+++ b/keras_preprocessing/image/image_data_generator.py
@@ -943,6 +943,9 @@ class ImageDataGenerator(object):
             np.random.seed(seed)
 
         x = np.copy(x)
+        if self.rescale:
+            x *= self.rescale
+
         if augment:
             ax = np.zeros(
                 tuple([rounds * x.shape[0]] + list(x.shape)[1:]),

--- a/keras_preprocessing/image/image_data_generator.py
+++ b/keras_preprocessing/image/image_data_generator.py
@@ -429,7 +429,8 @@ class ImageDataGenerator(object):
             save_to_dir=save_to_dir,
             save_prefix=save_prefix,
             save_format=save_format,
-            subset=subset
+            subset=subset,
+            dtype=self.dtype
         )
 
     def flow_from_directory(self,
@@ -537,7 +538,8 @@ class ImageDataGenerator(object):
             save_format=save_format,
             follow_links=follow_links,
             subset=subset,
-            interpolation=interpolation
+            interpolation=interpolation,
+            dtype=self.dtype
         )
 
     def flow_from_dataframe(self,
@@ -680,14 +682,15 @@ class ImageDataGenerator(object):
             save_format=save_format,
             subset=subset,
             interpolation=interpolation,
-            validate_filenames=validate_filenames
+            validate_filenames=validate_filenames,
+            dtype=self.dtype
         )
 
     def standardize(self, x):
         """Applies the normalization configuration in-place to a batch of inputs.
 
         `x` is changed in-place since the function is mainly used internally
-        to standarize images and feed them to your network. If a copy of `x`
+        to standardize images and feed them to your network. If a copy of `x`
         would be created instead it would have a significant performance cost.
         If you want to apply this method without changing the input in-place
         you can call the method creating a copy before:
@@ -909,6 +912,9 @@ class ImageDataGenerator(object):
 
         Only required if `featurewise_center` or
         `featurewise_std_normalization` or `zca_whitening` are set to True.
+
+        In case when `rescale` is set to a value, rescaling is applied to
+        sample data before computing the internal data stats.
 
         # Arguments
             x: Sample data. Should have rank 4.

--- a/keras_preprocessing/image/image_data_generator.py
+++ b/keras_preprocessing/image/image_data_generator.py
@@ -913,7 +913,7 @@ class ImageDataGenerator(object):
         Only required if `featurewise_center` or
         `featurewise_std_normalization` or `zca_whitening` are set to True.
 
-        In case when `rescale` is set to a value, rescaling is applied to
+        When `rescale` is set to a value, rescaling is applied to
         sample data before computing the internal data stats.
 
         # Arguments

--- a/tests/image/image_data_generator_test.py
+++ b/tests/image/image_data_generator_test.py
@@ -451,24 +451,41 @@ def test_fit_rescale(all_test_images):
             img_list.append(utils.img_to_array(im)[None, ...])
         images = np.vstack(img_list)
 
-        # featurewise_center and featurewise_std_normalization test
+        # featurewise_center test
         generator = image_data_generator.ImageDataGenerator(
             rescale=rescale,
             featurewise_center=True,
-            featurewise_std_normalization=True)
+            dtype='float64')
         generator.fit(images)
         batch = generator.flow(images, batch_size=8).next()
-        assert abs(np.mean(batch)) < 1e-3
-        assert abs(1 - np.std(batch)) < 1e-3
+        assert abs(np.mean(batch)) < 1e-6
+
+        # featurewise_std_normalization test
+        generator = image_data_generator.ImageDataGenerator(
+            rescale=rescale,
+            featurewise_center=True,
+            featurewise_std_normalization=True,
+            dtype='float64')
+        generator.fit(images)
+        batch = generator.flow(images, batch_size=8).next()
+        assert abs(np.mean(batch)) < 1e-6
+        assert abs(1 - np.std(batch)) < 1e-5
 
         # zca_whitening test
         generator = image_data_generator.ImageDataGenerator(
             rescale=rescale,
             featurewise_center=True,
-            zca_whitening=True)
+            zca_whitening=True,
+            dtype='float64')
         generator.fit(images)
         batch = generator.flow(images, batch_size=8).next()
-        assert np.max(np.abs(batch)) <= 1
+        batch = np.reshape(batch,
+                           (batch.shape[0],
+                            batch.shape[1] * batch.shape[2] * batch.shape[3]))
+        # Y * Y_T = n * I, where Y = W * X
+        identity = np.dot(batch, batch.T) / batch.shape[0]
+        assert ((np.abs(identity) - np.identity(identity.shape[0]))
+                < 1e-6).all()
 
 
 if __name__ == '__main__':

--- a/tests/image/image_data_generator_test.py
+++ b/tests/image/image_data_generator_test.py
@@ -452,18 +452,20 @@ def test_fit_rescale(all_test_images):
         images = np.vstack(img_list)
 
         # featurewise_center and featurewise_std_normalization test
-        generator = image_data_generator.ImageDataGenerator(rescale=rescale,
-                                                            featurewise_center=True,
-                                                            featurewise_std_normalization=True)
+        generator = image_data_generator.ImageDataGenerator(
+            rescale=rescale,
+            featurewise_center=True,
+            featurewise_std_normalization=True)
         generator.fit(images)
         batch = generator.flow(images, batch_size=8).next()
         assert abs(np.mean(batch)) < 1e-3
         assert abs(1 - np.std(batch)) < 1e-3
 
         # zca_whitening test
-        generator = image_data_generator.ImageDataGenerator(rescale=rescale,
-                                                            featurewise_center=True,
-                                                            zca_whitening=True)
+        generator = image_data_generator.ImageDataGenerator(
+            rescale=rescale,
+            featurewise_center=True,
+            zca_whitening=True)
         generator.fit(images)
         batch = generator.flow(images, batch_size=8).next()
         assert np.max(np.abs(batch)) <= 1

--- a/tests/image/image_data_generator_test.py
+++ b/tests/image/image_data_generator_test.py
@@ -442,5 +442,32 @@ def test_random_transforms():
     assert transform_dict['brightness'] is None
 
 
+def test_fit_rescale(all_test_images):
+    rescale = 1. / 255
+
+    for test_images in all_test_images:
+        img_list = []
+        for im in test_images:
+            img_list.append(utils.img_to_array(im)[None, ...])
+        images = np.vstack(img_list)
+
+        # featurewise_center and featurewise_std_normalization test
+        generator = image_data_generator.ImageDataGenerator(rescale=rescale,
+                                                            featurewise_center=True,
+                                                            featurewise_std_normalization=True)
+        generator.fit(images)
+        batch = generator.flow(images, batch_size=8).next()
+        assert abs(np.mean(batch)) < 1e-3
+        assert abs(1 - np.std(batch)) < 1e-3
+
+        # zca_whitening test
+        generator = image_data_generator.ImageDataGenerator(rescale=rescale,
+                                                            featurewise_center=True,
+                                                            zca_whitening=True)
+        generator.fit(images)
+        batch = generator.flow(images, batch_size=8).next()
+        assert np.max(np.abs(batch)) <= 1
+
+
 if __name__ == '__main__':
     pytest.main([__file__])


### PR DESCRIPTION
### Summary
Featurewise centering, normalization and ZCA whitening work incorrectly with the `rescale` parameter. This PR fixes the bug.

### Related Issues
#100 

### PR Overview
- [y] This PR requires new unit tests [y/n] (make sure tests are included)
- [n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
