### PR TITLE
autoclose files opened in load_img

### DIFF
--- a/keras_preprocessing/image/utils.py
+++ b/keras_preprocessing/image/utils.py
@@ -134,7 +134,7 @@ def load_img(path, grayscale=False, color_mode='rgb', target_size=None,
                             ", ".join(_PIL_INTERPOLATION_METHODS.keys())))
                 resample = _PIL_INTERPOLATION_METHODS[interpolation]
                 img = img.resize(width_height_tuple, resample)
-    return img
+        return img
 
 
 def list_pictures(directory, ext=('jpg', 'jpeg', 'bmp', 'png', 'ppm', 'tif',

--- a/keras_preprocessing/image/utils.py
+++ b/keras_preprocessing/image/utils.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import io
 import os
 import warnings
 
@@ -109,7 +110,8 @@ def load_img(path, grayscale=False, color_mode='rgb', target_size=None,
     if pil_image is None:
         raise ImportError('Could not import PIL.Image. '
                           'The use of `load_img` requires PIL.')
-    with pil_image.open(path) as img:
+    with open(path, 'rb') as f:
+        img = pil_image.open(io.BytesIO(f.read()))
         if color_mode == 'grayscale':
             # if image is not already an 8-bit, 16-bit or 32-bit grayscale image
             # convert it to an 8-bit grayscale image.

--- a/keras_preprocessing/image/utils.py
+++ b/keras_preprocessing/image/utils.py
@@ -109,31 +109,31 @@ def load_img(path, grayscale=False, color_mode='rgb', target_size=None,
     if pil_image is None:
         raise ImportError('Could not import PIL.Image. '
                           'The use of `load_img` requires PIL.')
-    img = pil_image.open(path)
-    if color_mode == 'grayscale':
-        # if image is not already an 8-bit, 16-bit or 32-bit grayscale image
-        # convert it to an 8-bit grayscale image.
-        if img.mode not in ('L', 'I;16', 'I'):
-            img = img.convert('L')
-    elif color_mode == 'rgba':
-        if img.mode != 'RGBA':
-            img = img.convert('RGBA')
-    elif color_mode == 'rgb':
-        if img.mode != 'RGB':
-            img = img.convert('RGB')
-    else:
-        raise ValueError('color_mode must be "grayscale", "rgb", or "rgba"')
-    if target_size is not None:
-        width_height_tuple = (target_size[1], target_size[0])
-        if img.size != width_height_tuple:
-            if interpolation not in _PIL_INTERPOLATION_METHODS:
-                raise ValueError(
-                    'Invalid interpolation method {} specified. Supported '
-                    'methods are {}'.format(
-                        interpolation,
-                        ", ".join(_PIL_INTERPOLATION_METHODS.keys())))
-            resample = _PIL_INTERPOLATION_METHODS[interpolation]
-            img = img.resize(width_height_tuple, resample)
+    with pil_image.open(path) as img:
+        if color_mode == 'grayscale':
+            # if image is not already an 8-bit, 16-bit or 32-bit grayscale image
+            # convert it to an 8-bit grayscale image.
+            if img.mode not in ('L', 'I;16', 'I'):
+                img = img.convert('L')
+        elif color_mode == 'rgba':
+            if img.mode != 'RGBA':
+                img = img.convert('RGBA')
+        elif color_mode == 'rgb':
+            if img.mode != 'RGB':
+                img = img.convert('RGB')
+        else:
+            raise ValueError('color_mode must be "grayscale", "rgb", or "rgba"')
+        if target_size is not None:
+            width_height_tuple = (target_size[1], target_size[0])
+            if img.size != width_height_tuple:
+                if interpolation not in _PIL_INTERPOLATION_METHODS:
+                    raise ValueError(
+                        'Invalid interpolation method {} specified. Supported '
+                        'methods are {}'.format(
+                            interpolation,
+                            ", ".join(_PIL_INTERPOLATION_METHODS.keys())))
+                resample = _PIL_INTERPOLATION_METHODS[interpolation]
+                img = img.resize(width_height_tuple, resample)
     return img
 
 

--- a/keras_preprocessing/image/utils.py
+++ b/keras_preprocessing/image/utils.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import io
 import os
 import warnings
 
@@ -109,7 +110,8 @@ def load_img(path, grayscale=False, color_mode='rgb', target_size=None,
     if pil_image is None:
         raise ImportError('Could not import PIL.Image. '
                           'The use of `load_img` requires PIL.')
-    with pil_image.load(path) as img:
+    with open(path, 'rb') as f:
+        img = pil_image.open(io.BytesIO(f.read()))
         if color_mode == 'grayscale':
             # if image is not already an 8-bit, 16-bit or 32-bit grayscale image
             # convert it to an 8-bit grayscale image.

--- a/keras_preprocessing/image/utils.py
+++ b/keras_preprocessing/image/utils.py
@@ -4,7 +4,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import io
 import os
 import warnings
 
@@ -110,8 +109,7 @@ def load_img(path, grayscale=False, color_mode='rgb', target_size=None,
     if pil_image is None:
         raise ImportError('Could not import PIL.Image. '
                           'The use of `load_img` requires PIL.')
-    with open(path, 'rb') as f:
-        img = pil_image.open(io.BytesIO(f.read()))
+    with pil_image.load(path) as img:
         if color_mode == 'grayscale':
             # if image is not already an 8-bit, 16-bit or 32-bit grayscale image
             # convert it to an 8-bit grayscale image.

--- a/keras_preprocessing/text.py
+++ b/keras_preprocessing/text.py
@@ -7,6 +7,7 @@ from __future__ import print_function
 
 import string
 import sys
+import six
 import warnings
 from collections import OrderedDict
 from collections import defaultdict
@@ -43,8 +44,10 @@ def text_to_word_sequence(text,
         text = text.lower()
 
     if sys.version_info < (3,):
-        if isinstance(text, unicode):
-            translate_map = dict((ord(c), unicode(split)) for c in filters)
+        # in Python 2.x six.string_types == basestring
+        # and basestring is a superclass for unicode and str
+        if isinstance(text, six.string_types) and not isinstance(text, str):
+            translate_map = dict((ord(c), six.u(split)) for c in filters)
             text = text.translate(translate_map)
         elif len(split) == 1:
             translate_map = maketrans(filters, split * len(filters))

--- a/keras_preprocessing/text.py
+++ b/keras_preprocessing/text.py
@@ -43,8 +43,10 @@ def text_to_word_sequence(text,
         text = text.lower()
 
     if sys.version_info < (3,):
-        if isinstance(text, unicode):
-            translate_map = dict((ord(c), unicode(split)) for c in filters)
+        if isinstance(text, unicode):  # noqa: F821
+            translate_map = dict(
+                (ord(c), unicode(split)) for c in filters  # noqa: F821
+            )
             text = text.translate(translate_map)
         elif len(split) == 1:
             translate_map = maketrans(filters, split * len(filters))

--- a/keras_preprocessing/text.py
+++ b/keras_preprocessing/text.py
@@ -7,7 +7,6 @@ from __future__ import print_function
 
 import string
 import sys
-import six
 import warnings
 from collections import OrderedDict
 from collections import defaultdict
@@ -44,10 +43,8 @@ def text_to_word_sequence(text,
         text = text.lower()
 
     if sys.version_info < (3,):
-        # in Python 2.x six.string_types == basestring
-        # and basestring is a superclass for unicode and str
-        if isinstance(text, six.string_types) and not isinstance(text, str):
-            translate_map = dict((ord(c), six.u(split)) for c in filters)
+        if isinstance(text, unicode):
+            translate_map = dict((ord(c), unicode(split)) for c in filters)
             text = text.translate(translate_map)
         elif len(split) == 1:
             translate_map = maketrans(filters, split * len(filters))

--- a/tests/image/utils_test.py
+++ b/tests/image/utils_test.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+import resource
 
 from keras_preprocessing.image import utils
 
@@ -325,6 +326,13 @@ def test_array_to_img_and_img_to_array():
         x = np.random.random((height, width, 5, 3))
         img = utils.img_to_array(x, data_format='channels_last')
 
+
+def test_image_file_handlers_close(tmpdir):
+    im = utils.array_to_img(np.random.rand(1,1,3))
+    path = str(tmpdir / 'sample_image.png')
+    utils.save_img(path, im)
+    max_open_files, _ = soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
+    images = [utils.load_img(path) for i in range(max_open_files+1)]
 
 if __name__ == '__main__':
     pytest.main([__file__])

--- a/tests/image/utils_test.py
+++ b/tests/image/utils_test.py
@@ -328,11 +328,13 @@ def test_array_to_img_and_img_to_array():
 
 
 def test_image_file_handlers_close(tmpdir):
-    im = utils.array_to_img(np.random.rand(1,1,3))
+    im = utils.array_to_img(np.random.rand(1, 1, 3))
     path = str(tmpdir / 'sample_image.png')
     utils.save_img(path, im)
     max_open_files, _ = soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
-    images = [utils.load_img(path) for i in range(max_open_files+1)]
+    for i in range(max_open_files+1):
+        utils.load_img(path)
+
 
 if __name__ == '__main__':
     pytest.main([__file__])

--- a/tests/image/utils_test.py
+++ b/tests/image/utils_test.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 import resource
+import PIL
 
 from keras_preprocessing.image import utils
 
@@ -344,8 +345,7 @@ def test_image_file_handlers_close(tmpdir):
 def test_load_img_returns_image(tmpdir):
     path = write_sample_image(tmpdir)
     im = utils.load_img(path)
-    assert hasattr(im, 'height')
-    assert hasattr(im, 'width')
+    assert isinstance(im, PIL.Image.Image)
 
 
 if __name__ == '__main__':

--- a/tests/image/utils_test.py
+++ b/tests/image/utils_test.py
@@ -337,7 +337,7 @@ def write_sample_image(tmpdir):
 
 def test_image_file_handlers_close(tmpdir):
     path = write_sample_image(tmpdir)
-    max_open_files, _ = soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
+    max_open_files, _ = resource.getrlimit(resource.RLIMIT_NOFILE)
     for i in range(max_open_files+1):
         utils.load_img(path)
 

--- a/tests/image/utils_test.py
+++ b/tests/image/utils_test.py
@@ -327,13 +327,25 @@ def test_array_to_img_and_img_to_array():
         img = utils.img_to_array(x, data_format='channels_last')
 
 
-def test_image_file_handlers_close(tmpdir):
+def write_sample_image(tmpdir):
     im = utils.array_to_img(np.random.rand(1, 1, 3))
     path = str(tmpdir / 'sample_image.png')
     utils.save_img(path, im)
+    return path
+
+
+def test_image_file_handlers_close(tmpdir):
+    path = write_sample_image(tmpdir)
     max_open_files, _ = soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
     for i in range(max_open_files+1):
         utils.load_img(path)
+
+
+def test_load_img_returns_image(tmpdir):
+    path = write_sample_image(tmpdir)
+    im = utils.load_img(path)
+    assert hasattr(im, 'height')
+    assert hasattr(im, 'width')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Summary

The current `load_img` function opens files but never closes them, which can cause `OSError: [Errno 24] Too many open files` if one reads in too many images in a process.

### Related Issues

https://github.com/keras-team/keras-preprocessing/issues/260

### PR Overview

- [n] This PR requires new unit tests [y/n] (make sure tests are included)
- [n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
