### PR TITLE
supply a single source for the version number

### DIFF
--- a/keras_preprocessing/__init__.py
+++ b/keras_preprocessing/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+import pkg_resources
 
 _KERAS_BACKEND = None
 _KERAS_UTILS = None
@@ -40,4 +41,4 @@ def get_keras_submodule(name):
         return _KERAS_UTILS
 
 
-__version__ = '1.1.0'
+__version__ = pkg_resources.get_distribution('keras_preprocessing').version


### PR DESCRIPTION
### Summary

Right now the `keras_preprocessing` version number is hardcoded in [`setup.py`](https://github.com/keras-team/keras-preprocessing/blob/master/setup.py#L26) and [the package's root level `__init__.py` file](https://github.com/keras-team/keras-preprocessing/blob/master/keras_preprocessing/__init__.py). This makes it cumbersome to change version numbers for development and testing purposes.

This PR uses one of the [recommended "single source version number" patterns](https://packaging.python.org/guides/single-sourcing-package-version/) to supply just a single version number.

### Related Issues

N/A

### PR Overview

- [n] This PR requires new unit tests [y/n] (make sure tests are included)
- [n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [n] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
