### PR TITLE
replace unicode typecasting with six.u to pass flake8 tests

### DIFF
--- a/keras_preprocessing/text.py
+++ b/keras_preprocessing/text.py
@@ -7,6 +7,7 @@ from __future__ import print_function
 
 import string
 import sys
+import six
 import warnings
 from collections import OrderedDict
 from collections import defaultdict
@@ -43,8 +44,10 @@ def text_to_word_sequence(text,
         text = text.lower()
 
     if sys.version_info < (3,):
-        if isinstance(text, unicode):
-            translate_map = dict((ord(c), unicode(split)) for c in filters)
+        # in Python 2.x six.string_types == basestring
+        # and basestring is a superclass for unicode and str
+        if isinstance(text, six.string_types) and not isinstance(text, str):
+            translate_map = dict((ord(c), six.u(split)) for c in filters)
             text = text.translate(translate_map)
         elif len(split) == 1:
             translate_map = maketrans(filters, split * len(filters))


### PR DESCRIPTION
### Summary

This PR replaces the `unicode()` [type reference](https://github.com/keras-team/keras-preprocessing/blob/master/keras_preprocessing/text.py#L46) and [typecasting call](https://github.com/keras-team/keras-preprocessing/blob/master/keras_preprocessing/text.py#L47) (both of which are only available in Python 2) in the text module with [`six.u()`](https://six.readthedocs.io/#six.u) which is available in Python 2 and 3. 

This change prevents flake8 from barking about undefined references when running flake tests in Python 3.

### Related Issues

N/A

### PR Overview

- [n] This PR requires new unit tests [y/n] (make sure tests are included)
- [n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)