### PR TITLE
Add Travis stage to run PEP8 in Pythonn 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ matrix:
         # check code style and Python 2.7
         - python: 2.7
           env: TEST_MODE=PEP8
+        # check code style and Python 3.6
+        - python: 3.6
+          env: TEST_MODE=PEP8
         # run tests with keras from source and Python 2.7
         - python: 2.7
           env: KERAS_HEAD=true

--- a/keras_preprocessing/text.py
+++ b/keras_preprocessing/text.py
@@ -43,8 +43,10 @@ def text_to_word_sequence(text,
         text = text.lower()
 
     if sys.version_info < (3,):
-        if isinstance(text, unicode):
-            translate_map = dict((ord(c), unicode(split)) for c in filters)
+        if isinstance(text, unicode):  # noqa: F821
+            translate_map = dict(
+                (ord(c), unicode(split)) for c in filters  # noqa: F821
+            )
             text = text.translate(translate_map)
         elif len(split) == 1:
             translate_map = maketrans(filters, split * len(filters))


### PR DESCRIPTION
### Summary
Currently PEP8 only runs with Python 2.7, even though small differences, they can still appear between running PEP8 with Python 2.7 and Python 3.6. For example `unicode` is an unknown word in Python 3.

The testing stage by itself would break as there is a PEP8 violation. This PR also introduces the fix. Basically there is a call to `unicode` if Python2 which if flagged as unknown in Python3 (you can check the build of the first commit).

### PR Overview

- [ n] This PR requires new unit tests [y/n] (make sure tests are included)
- [ n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [ y] This PR is backwards compatible [y/n]
- [ n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
