### PR TITLE
Added robust dtype check

### DIFF
--- a/keras_preprocessing/image/image_data_generator.py
+++ b/keras_preprocessing/image/image_data_generator.py
@@ -322,9 +322,9 @@ class ImageDataGenerator(object):
         self.std = None
         self.principal_components = None
 
-        if np.isscalar(zoom_range):
+        if isinstance(zoom_range, float):
             self.zoom_range = [1 - zoom_range, 1 + zoom_range]
-        elif len(zoom_range) == 2:
+        elif len(zoom_range) == 2 and all(isinstance(zoom_val, float) for zoom_val in zoom_range):
             self.zoom_range = [zoom_range[0], zoom_range[1]]
         else:
             raise ValueError('`zoom_range` should be a float or '


### PR DESCRIPTION
### Summary
`np.isscalar()` returns `True` for all scalars, including those that are not of type `float`. A better alternative is to use `isinstance()` to verify that `zoom_range` is either a float or a list/tuple of floats. 

### Related Issues
N/A

### PR Overview

- [n] This PR requires new unit tests [y/n] (make sure tests are included)
- [n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
