### PR TITLE
Minor optimization and dtype check

### DIFF
--- a/keras_preprocessing/image/image_data_generator.py
+++ b/keras_preprocessing/image/image_data_generator.py
@@ -322,10 +322,11 @@ class ImageDataGenerator(object):
         self.std = None
         self.principal_components = None
 
-        if np.isscalar(zoom_range):
+        if isinstance(zoom_range, float):
             self.zoom_range = [1 - zoom_range, 1 + zoom_range]
-        elif len(zoom_range) == 2:
-            self.zoom_range = [zoom_range[0], zoom_range[1]]
+        elif len(zoom_range) == 2 and 
+            all(isinstance(val, float) for val in zoom_range):
+                self.zoom_range = [zoom_range[0], zoom_range[1]]
         else:
             raise ValueError('`zoom_range` should be a float or '
                              'a tuple or list of two floats. '

--- a/keras_preprocessing/image/image_data_generator.py
+++ b/keras_preprocessing/image/image_data_generator.py
@@ -324,7 +324,7 @@ class ImageDataGenerator(object):
 
         if isinstance(zoom_range, float):
             self.zoom_range = [1 - zoom_range, 1 + zoom_range]
-        elif (len(zoom_range) == 2 and 
+        elif (len(zoom_range) == 2 and
               all(isinstance(val, float) for val in zoom_range)):
             self.zoom_range = [zoom_range[0], zoom_range[1]]
         else:

--- a/keras_preprocessing/image/image_data_generator.py
+++ b/keras_preprocessing/image/image_data_generator.py
@@ -324,8 +324,8 @@ class ImageDataGenerator(object):
 
         if isinstance(zoom_range, float):
             self.zoom_range = [1 - zoom_range, 1 + zoom_range]
-        elif len(zoom_range) == 2 and 
-            all(isinstance(val, float) for val in zoom_range):
+        elif len(zoom_range) == 2:
+            if all(isinstance(val, float) for val in zoom_range):
                 self.zoom_range = [zoom_range[0], zoom_range[1]]
         else:
             raise ValueError('`zoom_range` should be a float or '

--- a/keras_preprocessing/image/image_data_generator.py
+++ b/keras_preprocessing/image/image_data_generator.py
@@ -324,9 +324,9 @@ class ImageDataGenerator(object):
 
         if isinstance(zoom_range, float):
             self.zoom_range = [1 - zoom_range, 1 + zoom_range]
-        elif len(zoom_range) == 2:
-            if all(isinstance(val, float) for val in zoom_range):
-                self.zoom_range = [zoom_range[0], zoom_range[1]]
+        elif (len(zoom_range) == 2 and 
+              all(isinstance(val, float) for val in zoom_range)):
+            self.zoom_range = [zoom_range[0], zoom_range[1]]
         else:
             raise ValueError('`zoom_range` should be a float or '
                              'a tuple or list of two floats. '

--- a/keras_preprocessing/sequence.py
+++ b/keras_preprocessing/sequence.py
@@ -59,16 +59,16 @@ def pad_sequences(sequences, maxlen=None, dtype='int32',
     lengths = []
     sample_shape = ()
     flag = True
-    
+
     # take the sample shape from the first non empty sequence
     # checking for consistency in the main loop below.
-    
+
     for x in sequences:
         try:
             lengths.append(len(x))
             if flag and len(x):
-              sample_shape = np.asarray(x).shape[1:]
-              flag = False
+                sample_shape = np.asarray(x).shape[1:]
+                flag = False
         except TypeError:
             raise ValueError('`sequences` must be a list of iterables. '
                              'Found non-iterable: ' + str(x))

--- a/keras_preprocessing/sequence.py
+++ b/keras_preprocessing/sequence.py
@@ -57,23 +57,24 @@ def pad_sequences(sequences, maxlen=None, dtype='int32',
     num_samples = len(sequences)
 
     lengths = []
+    sample_shape = ()
+    flag = True
+    
+    # take the sample shape from the first non empty sequence
+    # checking for consistency in the main loop below.
+    
     for x in sequences:
         try:
             lengths.append(len(x))
+            if flag and len(x):
+              sample_shape = np.asarray(x).shape[1:]
+              flag = False
         except TypeError:
             raise ValueError('`sequences` must be a list of iterables. '
                              'Found non-iterable: ' + str(x))
 
     if maxlen is None:
         maxlen = np.max(lengths)
-
-    # take the sample shape from the first non empty sequence
-    # checking for consistency in the main loop below.
-    sample_shape = tuple()
-    for s in sequences:
-        if len(s) > 0:
-            sample_shape = np.asarray(s).shape[1:]
-            break
 
     is_dtype_str = np.issubdtype(dtype, np.str_) or np.issubdtype(dtype, np.unicode_)
     if isinstance(value, six.string_types) and dtype != object and not is_dtype_str:

--- a/keras_preprocessing/text.py
+++ b/keras_preprocessing/text.py
@@ -44,9 +44,9 @@ def text_to_word_sequence(text,
 
     if sys.version_info < (3,):
         if isinstance(text, unicode):  # noqa: F821
-            translate_map = dict(
-                (ord(c), unicode(split)) for c in filters  # noqa: F821
-            )
+            translate_map = {
+                ord(c): unicode(split) for c in filters  # noqa: F821
+            }
             text = text.translate(translate_map)
         elif len(split) == 1:
             translate_map = maketrans(filters, split * len(filters))
@@ -55,7 +55,7 @@ def text_to_word_sequence(text,
             for c in filters:
                 text = text.replace(c, split)
     else:
-        translate_dict = dict((c, split) for c in filters)
+        translate_dict = {c: split for c in filters}
         translate_map = maketrans(translate_dict)
         text = text.translate(translate_map)
 
@@ -193,8 +193,8 @@ class Tokenizer(object):
         self.char_level = char_level
         self.oov_token = oov_token
         self.index_docs = defaultdict(int)
-        self.word_index = dict()
-        self.index_word = dict()
+        self.word_index = {}
+        self.index_word = {}
 
     def fit_on_texts(self, texts):
         """Updates internal vocabulary based on a list of texts.
@@ -243,9 +243,9 @@ class Tokenizer(object):
 
         # note that index 0 is reserved, never assigned to an existing word
         self.word_index = dict(
-            list(zip(sorted_voc, list(range(1, len(sorted_voc) + 1)))))
+            zip(sorted_voc, list(range(1, len(sorted_voc) + 1))))
 
-        self.index_word = dict((c, w) for w, c in self.word_index.items())
+        self.index_word = {c: w for w, c in self.word_index.items()}
 
         for w, c in list(self.word_docs.items()):
             self.index_docs[self.word_index[w]] = c


### PR DESCRIPTION
### Summary

1.  Robust dtype check
`np.isscalar()` returns `True` for all scalars, not just floats or list/tuple of floats. Instead, use `isinstance()` to check dtype of `zoom_range`.

2. Dictionary code optimization
Use `{}` for dictionaries instead of `dict()` for readability and better performance.

### Related Issues
N/A

### PR Overview

- [n] This PR requires new unit tests [y/n] (make sure tests are included)
- [n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
