### PR TITLE
Remove Py 2.7 in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,29 +2,16 @@ sudo: required
 language: python
 matrix:
     include:
-        # check code style and Python 2.7
-        - python: 2.7
-          env: TEST_MODE=PEP8
         # check code style and Python 3.6
         - python: 3.6
           env: TEST_MODE=PEP8
-        # run tests with keras from source and Python 2.7
-        - python: 2.7
-          env: KERAS_HEAD=true
-          env: TEST_MODE=TESTS
         # run tests with keras from source and Python 3.6
         - python: 3.6
           env: KERAS_HEAD=true
           env: TEST_MODE=TESTS
-        # run tests with keras from PyPI and Python 2.7
-        - python: 2.7
-          env: TEST_MODE=TESTS
         # run tests with keras from PyPI and Python 3.6
         - python: 3.6
           env: TEST_MODE=TESTS
-        # run import test and Python 2.7
-        - python: 2.7
-          env: TEST_MODE=IMPORTS
         # run import test and Python 3.6
         - python: 3.6
           env: TEST_MODE=IMPORTS


### PR DESCRIPTION
### Summary
We can't merge any PR anymore due to Py2.7 not being supported by TF.

### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [ ] This PR is backwards compatible [y/n]
- [x] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
