### PR TITLE
Add scale param to brightness and fix some docs

### DIFF
--- a/keras_preprocessing/image/affine_transformations.py
+++ b/keras_preprocessing/image/affine_transformations.py
@@ -195,37 +195,41 @@ def random_channel_shift(x, intensity_range, channel_axis=0):
     return apply_channel_shift(x, intensity, channel_axis=channel_axis)
 
 
-def apply_brightness_shift(x, brightness):
+def apply_brightness_shift(x, brightness, scale=True):
     """Performs a brightness shift.
 
     # Arguments
         x: Input tensor. Must be 3D.
         brightness: Float. The new brightness value.
-        channel_axis: Index of axis for channels in the input tensor.
+        scale: Whether to rescale the image such that minimum and maximum values
+            are 0 and 255 respectively.
+            Default: True.
 
     # Returns
         Numpy image tensor.
 
     # Raises
-        ValueError if `brightness_range` isn't a tuple.
+        ImportError: if PIL is not available.
     """
     if ImageEnhance is None:
         raise ImportError('Using brightness shifts requires PIL. '
                           'Install PIL or Pillow.')
-    x = array_to_img(x)
+    x = array_to_img(x, scale=scale)
     x = imgenhancer_Brightness = ImageEnhance.Brightness(x)
     x = imgenhancer_Brightness.enhance(brightness)
     x = img_to_array(x)
     return x
 
 
-def random_brightness(x, brightness_range):
+def random_brightness(x, brightness_range, scale=True):
     """Performs a random brightness shift.
 
     # Arguments
         x: Input tensor. Must be 3D.
         brightness_range: Tuple of floats; brightness range.
-        channel_axis: Index of axis for channels in the input tensor.
+        scale: Whether to rescale the image such that minimum and maximum values
+            are 0 and 255 respectively.
+            Default: True.
 
     # Returns
         Numpy image tensor.
@@ -239,7 +243,7 @@ def random_brightness(x, brightness_range):
             'Received: %s' % (brightness_range,))
 
     u = np.random.uniform(brightness_range[0], brightness_range[1])
-    return apply_brightness_shift(x, u)
+    return apply_brightness_shift(x, u, scale)
 
 
 def transform_matrix_offset_center(matrix, x, y):

--- a/tests/image/affine_transformations_test.py
+++ b/tests/image/affine_transformations_test.py
@@ -46,13 +46,22 @@ def test_apply_brightness_shift_error(monkeypatch):
 
 def test_random_brightness(monkeypatch):
     monkeypatch.setattr(affine_transformations,
-                        'apply_brightness_shift', lambda x, y: (x, y))
+                        'apply_brightness_shift', lambda x, y, z: (x, y))
     assert (0, 3.) == affine_transformations.random_brightness(0, (3, 3))
 
 
 def test_random_brightness_error():
     with pytest.raises(ValueError):
         affine_transformations.random_brightness(0, [0])
+
+
+def test_random_brightness_scale():
+    img = np.ones((1, 1, 3)) * 128
+    zeros = np.zeros((1, 1, 3))
+    must_be_128 = affine_transformations.random_brightness(img, [1, 1], False)
+    assert np.array_equal(img, must_be_128)
+    must_be_0 = affine_transformations.random_brightness(img, [1, 1], True)
+    assert np.array_equal(zeros, must_be_0)
 
 
 def test_apply_affine_transform_error(monkeypatch):


### PR DESCRIPTION
### Summary
This add an option to not scale the image (to 0 - 255) when doing `random_brightness`. This also might fixes #114.

Code example :
```
brightness_range = [0.5, 2]
image = random_brightness(image, brightness_range, True) #for enable scale
image = random_brightness(image, brightness_range, False) #for disable scale

#or alternatively
image = random_brightness(image, brightness_range, scale=True)
image = random_brightness(image, brightness_range, scale=False)

#or call the apply_brightness_shift directly
image = apply_brightness_shift(image, 0.5, scale=True)
```

### Related Issues
There's no documentation about this on keras.io...

### PR Overview

- [x] This PR requires new unit tests [n] (make sure tests are included)
- [ ] This PR requires to update the documentation [?] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y]
- [x] This PR changes the current API [n] (all API changes need to be approved by fchollet)
