### PR TITLE
Ignore

### DIFF
--- a/keras_preprocessing/text.py
+++ b/keras_preprocessing/text.py
@@ -222,9 +222,19 @@ class Tokenizer(object):
                 a generator of strings (for memory-efficiency),
                 or a list of list of strings.
         """
+        filtered_characters = set(self.filters)
         for text in texts:
             self.document_count += 1
             if self.char_level or isinstance(text, list):
+                if isinstance(text, list):
+                    text = ["".join(char
+                                    for char in text_elem
+                                    if char not in filtered_characters)
+                            for text_elem in text]
+                else:
+                    text = "".join(char
+                                   for char in text
+                                   if char not in filtered_characters)
                 if self.lower:
                     if isinstance(text, list):
                         text = [text_elem.lower() for text_elem in text]

--- a/tests/text_test.py
+++ b/tests/text_test.py
@@ -184,6 +184,17 @@ def test_tokenizer_oov_flag_and_num_words():
     assert trans_text == 'this <unk> <unk> <unk> <unk> <unk>'
 
 
+def test_tokenizer_filter_char_level():
+    """It does not tokenize the characters in ``filters`` when ``char_level=True``
+    """
+    x_train = ['This text has only known words this text']
+
+    tokenizer = keras.preprocessing.text.Tokenizer(char_level=True,
+                                                   filters="e")
+    tokenizer.fit_on_texts(x_train)
+    assert "e" not in tokenizer.word_index
+
+
 def test_sequences_to_texts_with_num_words_and_oov_token():
     x_train = ['This text has only known words this text']
     x_test = ['This text has some unknown words']

--- a/tests/text_test.py
+++ b/tests/text_test.py
@@ -294,9 +294,8 @@ def test_tokenizer_lower_flag():
     char_tokenizer.fit_on_texts(texts)
     expected_word_counts = OrderedDict([('t', 11), ('h', 5), ('e', 6), (' ', 14),
                                         ('c', 2), ('a', 6), ('s', 2), ('o', 6),
-                                        ('n', 4), ('m', 1), ('.', 3), ('d', 3),
-                                        ('g', 5), ('l', 2), ('i', 2), ('v', 1),
-                                        ('r', 1)])
+                                        ('n', 4), ('m', 1), ('d', 3), ('g', 5),
+                                        ('l', 2), ('i', 2), ('v', 1), ('r', 1)])
     assert char_tokenizer.word_counts == expected_word_counts
 
 

--- a/tests/text_test.py
+++ b/tests/text_test.py
@@ -184,11 +184,13 @@ def test_tokenizer_oov_flag_and_num_words():
     assert trans_text == 'this <unk> <unk> <unk> <unk> <unk>'
 
 
-def test_tokenizer_filter_char_level():
+@pytest.mark.parametrize(
+    "x_train",
+    ("ae", ["ae", "er"], [["ae", "er"], ["ee", "a"]])
+)
+def test_tokenizer_filter_char_level(x_train):
     """It does not tokenize filtered characters at the character level.
     """
-    x_train = ['This text has only known words this text']
-
     tokenizer = text.Tokenizer(filters="e", char_level=True)
     tokenizer.fit_on_texts(x_train)
     assert "e" not in tokenizer.word_index

--- a/tests/text_test.py
+++ b/tests/text_test.py
@@ -189,8 +189,7 @@ def test_tokenizer_filter_char_level():
     """
     x_train = ['This text has only known words this text']
 
-    tokenizer = keras.preprocessing.text.Tokenizer(char_level=True,
-                                                   filters="e")
+    tokenizer = text.Tokenizer(filters="e", char_level=True)
     tokenizer.fit_on_texts(x_train)
     assert "e" not in tokenizer.word_index
 

--- a/tests/text_test.py
+++ b/tests/text_test.py
@@ -185,7 +185,7 @@ def test_tokenizer_oov_flag_and_num_words():
 
 
 def test_tokenizer_filter_char_level():
-    """It does not tokenize the characters in ``filters`` when ``char_level=True``
+    """It does not tokenize filtered characters at the character level.
     """
     x_train = ['This text has only known words this text']
 


### PR DESCRIPTION
### Summary

As outlined in #301, this PR makes `keras.preprocessing.text.Tokenizer` remove the characters in the `filters` argument if `char_level=True.`

Closes #301.

#### Behavior before

```python
❯ tokenizer = keras.preprocessing.text.Tokenizer(char_level=True, filters="e")
❯ tokenizer.fit_on_texts("ae")
❯ tokenizer.word_index
{'a': 1, 'e': 2}  # "e" is tokenized
```

#### Behavior after

```python
❯ tokenizer = keras.preprocessing.text.Tokenizer(char_level=True, filters="e")
❯ tokenizer.fit_on_texts("ae")
❯ tokenizer.word_index
{'a': 1}  # "e" is not tokenized
```

Closes #301 

### Related Issues

### PR Overview

- [x] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
