### PR TITLE
Updated keras_preprocessing image utils

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@
 
 ### PR Overview
 
-- [n] This PR requires new unit tests [y/n] (make sure tests are included)
-- [y] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
-- [y] This PR is backwards compatible [y/n]
-- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
+- [x] This PR requires new unit tests [y/n] (make sure tests are included)
+- [x] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
+- [x] This PR is backwards compatible [y/n]
+- [] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@
 
 ### PR Overview
 
-- [x] This PR requires new unit tests [y/n] (make sure tests are included)
-- [x] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
-- [x] This PR is backwards compatible [y/n]
+- [] This PR requires new unit tests [y/n] (make sure tests are included)
+- [] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
+- [] This PR is backwards compatible [y/n]
 - [] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@
 
 ### PR Overview
 
-- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
-- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
-- [ ] This PR is backwards compatible [y/n]
-- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
+- [n] This PR requires new unit tests [y/n] (make sure tests are included)
+- [y] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
+- [y] This PR is backwards compatible [y/n]
+- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)

--- a/keras_preprocessing/image/utils.py
+++ b/keras_preprocessing/image/utils.py
@@ -4,7 +4,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import io
 import os
 import warnings
 
@@ -110,7 +109,8 @@ def load_img(path, grayscale=False, color_mode='rgb', target_size=None,
     if pil_image is None:
         raise ImportError('Could not import PIL.Image. '
                           'The use of `load_img` requires PIL.')
-    img = pil_image.open(path) #read from path as well as bytes object
+    # read from path as well as bytes object
+    img = pil_image.open(path)
     if color_mode == 'grayscale':
         # if image is not already an 8-bit, 16-bit or 32-bit grayscale image
         # convert it to an 8-bit grayscale image.
@@ -227,7 +227,7 @@ def _list_valid_filenames_in_directory(directory, white_list_formats, split,
     return classes, filenames
 
 
-def array_to_img(x, data_format='channels_last', scale=True, is_grayscale=False, dtype='float32'):
+def array_to_img(x, data_format='channels_last', scale=True, is_gray=False, dtype='float32'):
     """Converts a 3D Numpy array to a PIL Image instance.
 
     # Arguments
@@ -237,7 +237,7 @@ def array_to_img(x, data_format='channels_last', scale=True, is_grayscale=False,
         scale: Whether to rescale the image such that minimum and maximum values
             are 0 and 255 respectively.
             Default: True.
-        is_grayscale: Whether image is grayscale.
+        is_gray: Whether image is grayscale.
             Default: False
         dtype: Dtype to use.
             Default: "float32".
@@ -254,15 +254,15 @@ def array_to_img(x, data_format='channels_last', scale=True, is_grayscale=False,
                           'The use of `array_to_img` requires PIL.')
     x = np.asarray(x, dtype=dtype)
     if x.ndim != 3:
-        # Grayscale image can be of ndim = 2, manually adding channel 1 for such cases
-        if is_grayscale:
+        # Grayscale image can be of ndim=2, manually adding channel 1 for such cases
+        if is_gray:
             if data_format == 'channels_last':
-                x = np.expand_dims(x,axis=2)
+                x = np.expand_dims(x, axis=2)
             else:
-                x = np.expand_dims(x,axis=0)
+                x = np.expand_dims(x, axis=0)
         else:
             raise ValueError('Expected image array to have rank 3 (single image). '
-                         'Got array with shape: %s' % (x.shape,))
+                             'Got array with shape: %s' % (x.shape,))
 
     if data_format not in {'channels_first', 'channels_last'}:
         raise ValueError('Invalid data_format: %s' % data_format)
@@ -314,7 +314,8 @@ def img_to_array(img, data_format='channels_last', dtype='float32'):
     # Numpy array x has format (height, width, channel)
     # or (channel, height, width)
     # but original PIL image has format (width, height, channel)
-    x = np.array(img, dtype=dtype) #retrieve a copy of image array (for better processing with cv2 functions)
+    # retrieve a copy of image array (for better processing with cv2 functions)
+    x = np.array(img, dtype=dtype)
     if len(x.shape) == 3:
         if data_format == 'channels_first':
             x = x.transpose(2, 0, 1)

--- a/keras_preprocessing/image/utils.py
+++ b/keras_preprocessing/image/utils.py
@@ -237,10 +237,10 @@ def array_to_img(x, data_format='channels_last', scale=True, is_grayscale=False,
         scale: Whether to rescale the image such that minimum and maximum values
             are 0 and 255 respectively.
             Default: True.
-        dtype: Dtype to use.
-            Default: "float32".
         is_grayscale: Whether image is grayscale.
             Default: False
+        dtype: Dtype to use.
+            Default: "float32".
 
     # Returns
         A PIL Image instance.
@@ -256,7 +256,10 @@ def array_to_img(x, data_format='channels_last', scale=True, is_grayscale=False,
     if x.ndim != 3:
         # Grayscale image can be of ndim = 2, manually adding channel 1 for such cases
         if is_grayscale:
-            x = np.expand_dims(x,axis=2)
+            if data_format == 'channels_last':
+                x = np.expand_dims(x,axis=2)
+            else:
+                x = np.expand_dims(x,axis=0)
         else:
             raise ValueError('Expected image array to have rank 3 (single image). '
                          'Got array with shape: %s' % (x.shape,))

--- a/tests/image/utils_test.py
+++ b/tests/image/utils_test.py
@@ -308,7 +308,7 @@ def test_array_to_img_and_img_to_array():
         dtype=np.int32
     )
     img = utils.array_to_img(x, is_grayscale=True)
-    assert img.size == (width,height)
+    assert img.size == (width, height)
 
     # Test invalid use case
     with pytest.raises(ValueError):

--- a/tests/image/utils_test.py
+++ b/tests/image/utils_test.py
@@ -302,6 +302,14 @@ def test_array_to_img_and_img_to_array():
     x = utils.img_to_array(img, data_format='channels_last')
     assert x.shape == (height, width, 1)
 
+    # 2D Grayscale array to image
+    x = np.array(
+        np.random.randint(-2147483648, 2147483647, (height, width)),
+        dtype=np.int32
+    )
+    img = utils.array_to_img(x, is_grayscale=True)
+    assert img.size == (width,height)
+
     # Test invalid use case
     with pytest.raises(ValueError):
         x = np.random.random((height, width))  # not 3D


### PR DESCRIPTION

### Summary
I have made some changes, that can be useful for people working on image processing.

1. image.load_img()
Gave me TypeError for loading bytes image, corrected the function to read an image from the path and BytesIO object.

2. image.array_to_img()
Used to fail on grayscale images because their ndim was less than 3, now added an optional flag is_grayscale to add single channel to grayscale image array with ndim = 2

3. image.img_to_array()
Replaced np.asarray() with np.array(), can be useful with cv2 functions, earlier np.asarray processed images gave different output when used with cv2 functions because array used to be modified. Now a copy of array is processed for use with cv2
### Related Issues

### PR Overview

- [x] This PR requires new unit tests [y/n] (make sure tests are included)
- [x] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [x] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
