### PR TITLE
Add balance in flow_from_directory to handle data imbalance (using random oversampling)

### DIFF
--- a/keras_preprocessing/image/directory_iterator.py
+++ b/keras_preprocessing/image/directory_iterator.py
@@ -11,7 +11,8 @@ from six.moves import range
 import numpy as np
 
 from .iterator import BatchFromFilesMixin, Iterator
-from .utils import _list_valid_filenames_in_directory
+from .utils import (_list_valid_filenames_in_directory,
+                    _make_balance_config)
 
 
 class DirectoryIterator(BatchFromFilesMixin, Iterator):
@@ -103,6 +104,13 @@ class DirectoryIterator(BatchFromFilesMixin, Iterator):
                                                             subset,
                                                             interpolation)
         self.directory = directory
+
+        if balance and subset != 'validation':
+            self._balance_config = _make_balance_config(directory, 
+                image_data_generator._validation_split)
+        else:
+            self._balance_config = None
+
         self.classes = classes
         if class_mode not in self.allowed_class_modes:
             raise ValueError('Invalid class_mode: {}; expected one of: {}'

--- a/keras_preprocessing/image/directory_iterator.py
+++ b/keras_preprocessing/image/directory_iterator.py
@@ -25,6 +25,7 @@ class DirectoryIterator(BatchFromFilesMixin, Iterator):
             via the `classes` argument.
         image_data_generator: Instance of `ImageDataGenerator`
             to use for random transformations and normalization.
+        balance: Boolean, will handle data imbalance if set to True.
         target_size: tuple of integers, dimensions to resize input images to.
         color_mode: One of `"rgb"`, `"rgba"`, `"grayscale"`.
             Color mode to read images.
@@ -76,6 +77,7 @@ class DirectoryIterator(BatchFromFilesMixin, Iterator):
     def __init__(self,
                  directory,
                  image_data_generator,
+                 balance = False,
                  target_size=(256, 256),
                  color_mode='rgb',
                  classes=None,

--- a/keras_preprocessing/image/directory_iterator.py
+++ b/keras_preprocessing/image/directory_iterator.py
@@ -139,7 +139,8 @@ class DirectoryIterator(BatchFromFilesMixin, Iterator):
             results.append(
                 pool.apply_async(_list_valid_filenames_in_directory,
                                  (dirpath, self.white_list_formats, self.split,
-                                  self.class_indices, follow_links)))
+                                  self.class_indices, follow_links,
+                                  self._balance_config)))
         classes_list = []
         for res in results:
             classes, filenames = res.get()

--- a/keras_preprocessing/image/image_data_generator.py
+++ b/keras_preprocessing/image/image_data_generator.py
@@ -441,6 +441,7 @@ class ImageDataGenerator(object):
 
     def flow_from_directory(self,
                             directory,
+                            balance = False,
                             target_size=(256, 256),
                             color_mode='rgb',
                             classes=None,
@@ -465,6 +466,7 @@ class ImageDataGenerator(object):
                 See [this script](
                 https://gist.github.com/fchollet/0830affa1f7f19fd47b06d4cf89ed44d)
                 for more details.
+            balance: Boolean, handles data imbalance if True
             target_size: Tuple of integers `(height, width)`,
                 default: `(256, 256)`.
                 The dimensions to which all images found will be resized.

--- a/keras_preprocessing/image/image_data_generator.py
+++ b/keras_preprocessing/image/image_data_generator.py
@@ -533,6 +533,7 @@ class ImageDataGenerator(object):
         return DirectoryIterator(
             directory,
             self,
+            balance=balance,
             target_size=target_size,
             color_mode=color_mode,
             classes=classes,

--- a/keras_preprocessing/image/utils.py
+++ b/keras_preprocessing/image/utils.py
@@ -238,11 +238,9 @@ def _generate_class_count(directory):
     
     class_count = {}
 
-    if directory[-1] != '/':
-        directory += '/'
-
     for category in os.listdir(directory):
-      class_count[category] = len(os.listdir(directory + category))
+      category_directory = os.path.join(directory, category)
+      class_count[category] = len(os.listdir(category_directory))
 
     return class_count
 

--- a/keras_preprocessing/image/utils.py
+++ b/keras_preprocessing/image/utils.py
@@ -227,9 +227,28 @@ def _list_valid_filenames_in_directory(directory, white_list_formats, split,
 
     return classes, filenames
 
+def _generate_class_count(directory):
+    """Maintain sample count of each class in the directory.
+    
+    # Arguments
+        directory: string, absolute path to the directory
+    # Returns
+        class_count: dictionary, sample count for each class
+    """
+    
+    class_count = {}
+
+    if directory[-1] != '/':
+        directory += '/'
+
+    for category in os.listdir(directory):
+      class_count[category] = len(os.listdir(directory + category))
+
+    return class_count
 
 def _make_balance_config(directory, validation_split):
     """Scans the directory to make a config dictionary to handle data imbalance.
+    
     # Arguments
         directory: string, absolute path to the directory
         validation_split: float, validation split

--- a/keras_preprocessing/image/utils.py
+++ b/keras_preprocessing/image/utils.py
@@ -228,6 +228,29 @@ def _list_valid_filenames_in_directory(directory, white_list_formats, split,
     return classes, filenames
 
 
+def _make_balance_config(directory, validation_split):
+    """Scans the directory to make a config dictionary to handle data imbalance.
+    # Arguments
+        directory: string, absolute path to the directory
+        validation_split: float, validation split
+            Default: None
+    # Returns
+        balance_config: dictionary, specs needed to handle data imbalance
+            'majority': integer, number of samples in the majority class
+    """
+    class_count = _generate_class_count(directory)
+
+    # Get the sample count of the majority class
+    majority_class_count = class_count[max(class_count, key = class_count.get)]
+    if validation_split:
+        majority_class_count = int(majority_class_count*(1 - validation_split)) + 1        
+
+    balance_config = {
+        'majority': majority_class_count
+    }
+
+    return balance_config
+
 def array_to_img(x, data_format='channels_last', scale=True, dtype='float32'):
     """Converts a 3D Numpy array to a PIL Image instance.
 

--- a/keras_preprocessing/image/utils.py
+++ b/keras_preprocessing/image/utils.py
@@ -7,6 +7,7 @@ from __future__ import print_function
 import io
 import os
 import warnings
+import random
 
 import numpy as np
 
@@ -181,6 +182,19 @@ def _iter_valid_files(directory, white_list_formats, follow_links):
             if fname.lower().endswith(white_list_formats):
                 yield root, fname
 
+def _settle_debt(list_valid_files, debt):
+    """Iterates over list_valid_files and resamples to settle debt.
+
+    # Arguments:
+        list_valid_files: List of strings, list that contains valid filenames
+        debt: Integer, required number of samples to be resampled from
+            valid_file_names
+
+    # Yields:
+        randomly chosen filename from list_valid_files 
+    """
+    for i in range(debt):
+        yield random.choice(list_valid_files)
 
 def _list_valid_filenames_in_directory(directory, white_list_formats, split,
                                        class_indices, follow_links, 

--- a/keras_preprocessing/image/utils.py
+++ b/keras_preprocessing/image/utils.py
@@ -183,7 +183,8 @@ def _iter_valid_files(directory, white_list_formats, follow_links):
 
 
 def _list_valid_filenames_in_directory(directory, white_list_formats, split,
-                                       class_indices, follow_links):
+                                       class_indices, follow_links, 
+                                       balance_config = None):
     """Lists paths of files in `subdir` with extensions in `white_list_formats`.
 
     # Arguments
@@ -198,6 +199,7 @@ def _list_valid_filenames_in_directory(directory, white_list_formats, split,
             of images in each directory.
         class_indices: dictionary mapping a class name to its index.
         follow_links: boolean, follow symbolic links to subdirectories.
+        balance_config: dict, stores configurations for handling data imbalance.
 
     # Returns
          classes: a list of class indices
@@ -224,6 +226,15 @@ def _list_valid_filenames_in_directory(directory, white_list_formats, split,
         relative_path = os.path.join(
             dirname, os.path.relpath(absolute_path, directory))
         filenames.append(relative_path)
+
+    if balance_config:
+        filenames_copy = filenames.copy()
+
+        debt = balance_config['majority'] - len(filenames_copy)
+
+        for filename in _settle_debt(filenames_copy, debt):
+            classes.append(class_indices[dirname])
+            filenames.append(filename)
 
     return classes, filenames
 


### PR DESCRIPTION
### Summary 

This PR helps us balance the imbalanced classes using random oversampling.

Introduces a new argument, __balance__, in `DirectoryIterator`. This argument is boolean in nature. (accepts `True/False`)

### Example: 

```python3
data_train_dir = 'data/train'

from keras_preprocessing.image import ImageDataGenerator
datagen = ImageDataGenerator(validation_split=0.2)

train_gen = datagen.flow_from_directory(data_train_dir, subset = 'training', 
                                        balance = True)

valid_gen = datagen.flow_from_directory(data_train_dir, subset = 'validation', 
                                        balance = True)
```


__Only the training subset undergoes oversampling. [Validation subset is excluded from oversampling](https://github.com/DOLARIK/keras-preprocessing/blob/71cabcf53690792a8bc762944bf96729e9d9165d/keras_preprocessing/image/directory_iterator.py#L108). This is done as we use random oversampling only to increase the number of samples in the training dataset for robust learning.__

I have created a Colab Notebook to play around with this new feature: 

[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/17uDk3P6R1b_sZyeqv8KPBHi15ovDQy9t?usp=sharing)

### Underlying Concept:

Consider an imbalanced dataset having categories __A, B and C__, with the following files in the respective sub-directories:

```bash
data
|____train________ ___________________ __________________
                  |                   |                  |
                  A                   B                  C
                  |__A_0.jpg          |__B_0.jpg         |__C_0.jpg
                  |__A_1.jpg          |__B_1.jpg         |__C_1.jpg
                  |__A_2.jpg                             |__C_2.jpg
                  |__A_3.jpg           
```
As seen here, __majority count here is 4__ (in __A__), so the count in all the other categories too will be made 4 by [randomly sampling a filename from the original set of filenames](https://github.com/DOLARIK/keras-preprocessing/blob/71cabcf53690792a8bc762944bf96729e9d9165d/keras_preprocessing/image/utils.py#L249) from the respective __sub-directories__ (category directories):
  
```bash
data
|____train________ ___________________ __________________
                  |                   |                  |
                  A                   B                  C
                  |__A_0.jpg          |__B_0.jpg         |__C_0.jpg
                  |__A_1.jpg          |__B_1.jpg         |__C_1.jpg
                  |__A_2.jpg          |--B_1.jpg         |__C_2.jpg
                  |__A_3.jpg          |--B_0.jpg         |--C_0.jpg           
```
Here, from __B__, after randomly oversampling from `[B_0.jpg, B_1.jpg]` and appending them to the list, to make the total filenames equal to __4 (the majority count)__ we got `[B_0.jpg, B_1.jpg,` __`B_1.jpg, B_0.jpg`__`]`. (resampled filenames are in __bold__)

Similarly, for __C__, after random oversampling, we got `[C_0.jpg, C_1.jpg,  C_2.jpg,` __`C_0.jpg`__`]` (resampled filenames are in __bold__)

__After Data Augmentation:__

- Random Rotation - __[0,90]__ degrees
- Nomenclature: __filename.{rotation_angle}__

```bash
data
|____train________ ___________________ __________________
                  |                   |                  |
                  A                   B                  C
                  |__A_0.jpg.{67}     |__B_0.jpg.{12}    |__C_0.jpg.{42}
                  |__A_1.jpg.{55}     |__B_1.jpg.{43}    |__C_1.jpg.{20}
                  |__A_2.jpg.{32}     |--B_1.jpg.{05}    |__C_2.jpg.{71}
                  |__A_3.jpg.{45}     |--B_0.jpg.{10}    |--C_0.jpg.{80}           
```
Notice that __B_1.jpg{43}__ and __B_1.jpg{05}__ are technically two different images. So, this is how with __random oversampling using data augmentation__, we can increase the number of samples in our dataset.

This feature has helped me handle data imbalance without using external libraries and keep the whole training pipeline clean, smooth and simple. I hope it'll help others too.

I am still figuring out the best practices for creating unit tests and updating the docs, therefore have not been able to add new tests for this feature yet. So, for you to test this out now, I have created this [Colab Notebook](https://colab.research.google.com/drive/17uDk3P6R1b_sZyeqv8KPBHi15ovDQy9t?usp=sharing). __It includes demo data directory and visualizations.__ I will soon add appropriate tests.

__This new feature has passed all the pre-existing tests.__

### PR Overview

- [ ] This PR requires new unit tests [y] (make sure tests are included)
- [ ] This PR requires to update the documentation [y] (make sure the docs are up-to-date)
- [ ] This PR is backwards compatible [?]
- [ ] This PR changes the current API [y] (all API changes need to be approved by fchollet)
