### PR TITLE
Set matrix center correctly

### DIFF
--- a/keras_preprocessing/image/affine_transformations.py
+++ b/keras_preprocessing/image/affine_transformations.py
@@ -247,8 +247,8 @@ def random_brightness(x, brightness_range, scale=True):
 
 
 def transform_matrix_offset_center(matrix, x, y):
-    o_x = float(x) / 2 + 0.5
-    o_y = float(y) / 2 + 0.5
+    o_x = float(x) / 2 - 0.5
+    o_y = float(y) / 2 - 0.5
     offset_matrix = np.array([[1, 0, o_x], [0, 1, o_y], [0, 0, 1]])
     reset_matrix = np.array([[1, 0, -o_x], [0, 1, -o_y], [0, 0, 1]])
     transform_matrix = np.dot(np.dot(offset_matrix, matrix), reset_matrix)

--- a/tests/image/affine_transformations_test.py
+++ b/tests/image/affine_transformations_test.py
@@ -15,14 +15,14 @@ def test_random_transforms():
 def test_deterministic_transform():
     x = np.ones((3, 3, 3))
     x_rotated = np.array([[[0., 0., 0.],
-                           [0., 0., 0.],
-                           [1., 1., 1.]],
-                          [[0., 0., 0.],
+                           [1., 1., 1.],
+                           [0., 0., 0.]],
+                          [[1., 1., 1.],
                            [1., 1., 1.],
                            [1., 1., 1.]],
                           [[0., 0., 0.],
-                           [0., 0., 0.],
-                           [1., 1., 1.]]])
+                           [1., 1., 1.],
+                           [0., 0., 0.]]])
     assert np.allclose(affine_transformations.apply_affine_transform(
         x, theta=45, channel_axis=2, fill_mode='constant'), x_rotated)
 

--- a/tests/image/affine_transformations_test.py
+++ b/tests/image/affine_transformations_test.py
@@ -27,6 +27,21 @@ def test_deterministic_transform():
         x, theta=45, channel_axis=2, fill_mode='constant'), x_rotated)
 
 
+def test_matrix_center():
+    x = np.expand_dims(np.array([
+        [0, 1],
+        [0, 0],
+    ]), -1)
+    x_rotated90 = np.expand_dims(np.array([
+        [0, 0],
+        [0, 1],
+    ]), -1)
+
+    assert np.allclose(
+        affine_transformations.apply_affine_transform(x, theta=90),
+        x_rotated90)
+
+
 def test_random_zoom():
     x = np.random.random((2, 28, 28))
     assert affine_transformations.random_zoom(x, (5, 5)).shape == (2, 28, 28)

--- a/tests/image/image_data_generator_test.py
+++ b/tests/image/image_data_generator_test.py
@@ -389,14 +389,14 @@ def test_deterministic_transform():
                        x[:, ::-1, :])
     x = np.ones((3, 3, 3))
     x_rotated = np.array([[[0., 0., 0.],
-                           [0., 0., 0.],
-                           [1., 1., 1.]],
-                          [[0., 0., 0.],
+                           [1., 1., 1.],
+                           [0., 0., 0.]],
+                          [[1., 1., 1.],
                            [1., 1., 1.],
                            [1., 1., 1.]],
                           [[0., 0., 0.],
-                           [0., 0., 0.],
-                           [1., 1., 1.]]])
+                           [1., 1., 1.],
+                           [0., 0., 0.]]])
     assert np.allclose(generator.apply_transform(x, {'theta': 45}),
                        x_rotated)
 


### PR DESCRIPTION
Matrix center was set incorrectly (one off). To correct either call transform_matrix_offset_center() with h-1 ,w-1. Or  fix the sign inside that function and continue using h and w (more intuitive).

### Summary

### Related Issues

### PR Overview

- [n] This PR requires new unit tests [y/n] (make sure tests are included)
- [n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
