### PR TITLE
Remove Python2 from CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ matrix:
         # run tests with keras from PyPI and Python 3.6
         - python: 3.6
           env: TEST_MODE=TESTS
-        # run import test and Python 2.7
         # run import test and Python 3.6
         - python: 3.6
           env: TEST_MODE=IMPORTS

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,29 +2,17 @@ sudo: required
 language: python
 matrix:
     include:
-        # check code style and Python 2.7
-        - python: 2.7
-          env: TEST_MODE=PEP8
         # check code style and Python 3.6
         - python: 3.6
           env: TEST_MODE=PEP8
-        # run tests with keras from source and Python 2.7
-        - python: 2.7
-          env: KERAS_HEAD=true
-          env: TEST_MODE=TESTS
         # run tests with keras from source and Python 3.6
         - python: 3.6
           env: KERAS_HEAD=true
-          env: TEST_MODE=TESTS
-        # run tests with keras from PyPI and Python 2.7
-        - python: 2.7
           env: TEST_MODE=TESTS
         # run tests with keras from PyPI and Python 3.6
         - python: 3.6
           env: TEST_MODE=TESTS
         # run import test and Python 2.7
-        - python: 2.7
-          env: TEST_MODE=IMPORTS
         # run import test and Python 3.6
         - python: 3.6
           env: TEST_MODE=IMPORTS
@@ -32,13 +20,7 @@ matrix:
 
 before_install:
   - sudo apt-get update
-  # We do this conditionally because it saves us some downloading if the
-  # version is the same.
-  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
-      wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;
-    else
-      wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
-    fi
+  - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r


### PR DESCRIPTION
Abandon Python2 tests in CI

### Summary

### Related Issues

### PR Overview

- [n] This PR requires new unit tests [y/n] (make sure tests are included)
- [n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [n] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
