### PR TITLE
Get rid of Python2

### DIFF
--- a/keras_preprocessing/__init__.py
+++ b/keras_preprocessing/__init__.py
@@ -1,8 +1,5 @@
 """Enables dynamic setting of underlying Keras module.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 _KERAS_BACKEND = None
 _KERAS_UTILS = None

--- a/keras_preprocessing/image/__init__.py
+++ b/keras_preprocessing/image/__init__.py
@@ -1,6 +1,5 @@
 """Enables dynamic setting of underlying Keras module.
 """
-from __future__ import absolute_import
 # flake8: noqa:F401
 from .affine_transformations import *
 from .dataframe_iterator import DataFrameIterator

--- a/keras_preprocessing/image/affine_transformations.py
+++ b/keras_preprocessing/image/affine_transformations.py
@@ -1,13 +1,8 @@
 """Utilities for performing affine transformations on image data.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import numpy as np
 
-from .utils import (array_to_img,
-                    img_to_array)
+from .utils import array_to_img, img_to_array
 
 try:
     import scipy
@@ -17,8 +12,8 @@ except ImportError:
     scipy = None
 
 try:
-    from PIL import ImageEnhance
     from PIL import Image as pil_image
+    from PIL import ImageEnhance
 except ImportError:
     pil_image = None
     ImageEnhance = None

--- a/keras_preprocessing/image/dataframe_iterator.py
+++ b/keras_preprocessing/image/dataframe_iterator.py
@@ -1,14 +1,10 @@
 """Utilities for real-time data augmentation on image data.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import os
 import warnings
+from collections import OrderedDict
 
 import numpy as np
-from collections import OrderedDict
 
 from .iterator import BatchFromFilesMixin, Iterator
 from .utils import validate_filename

--- a/keras_preprocessing/image/directory_iterator.py
+++ b/keras_preprocessing/image/directory_iterator.py
@@ -1,12 +1,7 @@
 """Utilities for real-time data augmentation on image data.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
-import os
 import multiprocessing.pool
-from six.moves import range
+import os
 
 import numpy as np
 

--- a/keras_preprocessing/image/image_data_generator.py
+++ b/keras_preprocessing/image/image_data_generator.py
@@ -1,11 +1,6 @@
 """Utilities for real-time data augmentation on image data.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import warnings
-from six.moves import range
 
 import numpy as np
 
@@ -13,17 +8,17 @@ try:
     import scipy
     # scipy.linalg cannot be accessed until explicitly imported
     from scipy import linalg
+
     # scipy.ndimage cannot be accessed until explicitly imported
 except ImportError:
     scipy = None
 
+from .affine_transformations import (apply_affine_transform,
+                                     apply_brightness_shift,
+                                     apply_channel_shift, flip_axis)
 from .dataframe_iterator import DataFrameIterator
 from .directory_iterator import DirectoryIterator
 from .numpy_array_iterator import NumpyArrayIterator
-from .affine_transformations import (apply_affine_transform,
-                                     apply_brightness_shift,
-                                     apply_channel_shift,
-                                     flip_axis)
 
 
 class ImageDataGenerator(object):

--- a/keras_preprocessing/image/iterator.py
+++ b/keras_preprocessing/image/iterator.py
@@ -1,12 +1,10 @@
 """Utilities for real-time data augmentation on image data.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import os
 import threading
+
 import numpy as np
+
 from keras_preprocessing import get_keras_submodule
 
 try:
@@ -14,9 +12,7 @@ try:
 except ImportError:
     IteratorType = object
 
-from .utils import (array_to_img,
-                    img_to_array,
-                    load_img)
+from .utils import array_to_img, img_to_array, load_img
 
 
 class Iterator(IteratorType):

--- a/keras_preprocessing/image/numpy_array_iterator.py
+++ b/keras_preprocessing/image/numpy_array_iterator.py
@@ -1,11 +1,8 @@
 """Utilities for real-time data augmentation on image data.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import os
 import warnings
+
 import numpy as np
 
 from .iterator import Iterator

--- a/keras_preprocessing/image/utils.py
+++ b/keras_preprocessing/image/utils.py
@@ -1,9 +1,5 @@
 """Utilities for real-time data augmentation on image data.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import io
 import os
 import warnings
@@ -11,8 +7,8 @@ import warnings
 import numpy as np
 
 try:
-    from PIL import ImageEnhance
     from PIL import Image as pil_image
+    from PIL import ImageEnhance
 except ImportError:
     pil_image = None
     ImageEnhance = None

--- a/keras_preprocessing/sequence.py
+++ b/keras_preprocessing/sequence.py
@@ -1,15 +1,10 @@
 # -*- coding: utf-8 -*-
 """Utilities for preprocessing sequence data.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+import json
+import random
 
 import numpy as np
-import random
-import json
-from six.moves import range
-import six
 
 
 def pad_sequences(sequences, maxlen=None, dtype='int32',
@@ -77,7 +72,7 @@ def pad_sequences(sequences, maxlen=None, dtype='int32',
         maxlen = np.max(lengths)
 
     is_dtype_str = np.issubdtype(dtype, np.str_) or np.issubdtype(dtype, np.unicode_)
-    if isinstance(value, six.string_types) and dtype != object and not is_dtype_str:
+    if isinstance(value, str) and dtype != object and not is_dtype_str:
         raise ValueError("`dtype` {} is not compatible with `value`'s type: {}\n"
                          "You should set `dtype=object` for variable length strings."
                          .format(dtype, type(value)))

--- a/keras_preprocessing/text.py
+++ b/keras_preprocessing/text.py
@@ -1,26 +1,14 @@
 # -*- coding: utf-8 -*-
 """Utilities for text input preprocessing.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
-import string
-import sys
-import warnings
-from collections import OrderedDict
-from collections import defaultdict
-from hashlib import md5
 import json
+import warnings
+from collections import OrderedDict, defaultdict
+from hashlib import md5
 
 import numpy as np
-from six.moves import range
-from six.moves import zip
 
-if sys.version_info < (3,):
-    maketrans = string.maketrans
-else:
-    maketrans = str.maketrans
+maketrans = str.maketrans
 
 
 def text_to_word_sequence(text,
@@ -42,22 +30,9 @@ def text_to_word_sequence(text,
     if lower:
         text = text.lower()
 
-    if sys.version_info < (3,):
-        if isinstance(text, unicode):  # noqa: F821
-            translate_map = {
-                ord(c): unicode(split) for c in filters  # noqa: F821
-            }
-            text = text.translate(translate_map)
-        elif len(split) == 1:
-            translate_map = maketrans(filters, split * len(filters))
-            text = text.translate(translate_map)
-        else:
-            for c in filters:
-                text = text.replace(c, split)
-    else:
-        translate_dict = {c: split for c in filters}
-        translate_map = maketrans(translate_dict)
-        text = text.translate(translate_map)
+    translate_dict = {c: split for c in filters}
+    translate_map = maketrans(translate_dict)
+    text = text.translate(translate_map)
 
     seq = text.split(split)
     return [i for i in seq if i]

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,4 @@
-import sys
-
-from setuptools import setup
-from setuptools import find_packages
+from setuptools import find_packages, setup
 
 long_description = '''
 Keras Preprocessing is the data preprocessing
@@ -18,7 +15,7 @@ from an up-to-date installation of Keras:
 from keras import preprocessing
 ```
 
-Keras Preprocessing is compatible with Python 2.7-3.6
+Keras Preprocessing is compatible with Python 3.6
 and is distributed under the MIT license.
 '''
 
@@ -32,11 +29,10 @@ setup(name='Keras_Preprocessing',
       download_url='https://github.com/keras-team/'
                    'keras-preprocessing/tarball/1.1.2',
       license='MIT',
-      install_requires=['numpy>=1.9.1',
-                        'six>=1.9.0'],
+      install_requires=['numpy>=1.9.1'],
       extras_require={
           'tests': ['pandas',
-                    'Pillow' if sys.version_info >= (3, 0) else 'pillow',
+                    'Pillow',
                     'tensorflow',  # CPU version
                     'keras',
                     'pytest',
@@ -52,8 +48,6 @@ setup(name='Keras_Preprocessing',
           'Intended Audience :: Education',
           'Intended Audience :: Science/Research',
           'License :: OSI Approved :: MIT License',
-          'Programming Language :: Python :: 2',
-          'Programming Language :: Python :: 2.7',
           'Programming Language :: Python :: 3',
           'Programming Language :: Python :: 3.6',
           'Topic :: Software Development :: Libraries',

--- a/tests/image/dataframe_iterator_test.py
+++ b/tests/image/dataframe_iterator_test.py
@@ -5,11 +5,9 @@ import shutil
 import numpy as np
 import pandas as pd
 import pytest
-
 from PIL import Image
 
-from keras_preprocessing.image import dataframe_iterator
-from keras_preprocessing.image import image_data_generator
+from keras_preprocessing.image import dataframe_iterator, image_data_generator
 
 
 @pytest.fixture(scope='module')

--- a/tests/image/directory_iterator_test.py
+++ b/tests/image/directory_iterator_test.py
@@ -4,7 +4,6 @@ import tempfile
 
 import numpy as np
 import pytest
-
 from PIL import Image
 
 from keras_preprocessing.image import image_data_generator

--- a/tests/image/image_data_generator_test.py
+++ b/tests/image/image_data_generator_test.py
@@ -1,10 +1,8 @@
 import numpy as np
 import pytest
-
 from PIL import Image
 
-from keras_preprocessing.image import image_data_generator
-from keras_preprocessing.image import utils
+from keras_preprocessing.image import image_data_generator, utils
 
 
 @pytest.fixture(scope='module')

--- a/tests/image/numpy_array_iterator_test.py
+++ b/tests/image/numpy_array_iterator_test.py
@@ -1,10 +1,8 @@
 import numpy as np
 import pytest
-
 from PIL import Image
 
-from keras_preprocessing.image import numpy_array_iterator
-from keras_preprocessing.image import utils
+from keras_preprocessing.image import numpy_array_iterator, utils
 from keras_preprocessing.image.image_data_generator import ImageDataGenerator
 
 

--- a/tests/image/utils_test.py
+++ b/tests/image/utils_test.py
@@ -1,7 +1,8 @@
-import numpy as np
-import pytest
 import resource
+
+import numpy as np
 import PIL
+import pytest
 
 from keras_preprocessing.image import utils
 

--- a/tests/sequence_test.py
+++ b/tests/sequence_test.py
@@ -1,9 +1,8 @@
 from math import ceil
-import pytest
+
 import numpy as np
-from numpy.testing import assert_allclose
-from numpy.testing import assert_equal
-from numpy.testing import assert_raises
+import pytest
+from numpy.testing import assert_allclose, assert_equal, assert_raises
 
 from keras_preprocessing import sequence
 

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -1,7 +1,6 @@
 import importlib
 import inspect
 import re
-import sys
 from itertools import compress
 
 import pytest
@@ -163,7 +162,6 @@ def handle_module(mod):
             handle_module(mem)
 
 
-@pytest.mark.skipif(sys.version_info < (3, 3), reason="requires python3.3")
 def test_doc():
     for module in modules:
         mod = importlib.import_module(module)

--- a/tests/text_test.py
+++ b/tests/text_test.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
+from collections import OrderedDict
+
 import numpy as np
 import pytest
-
 from tensorflow import keras
+
 from keras_preprocessing import text
-from collections import OrderedDict
 
 
 def test_one_hot():


### PR DESCRIPTION
### Summary

### Related Issues

### PR Overview

- [n] This PR requires new unit tests [y/n] (make sure tests are included)
- [n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)

Removed Python2 code because `keras_preprocessing` is incompatible with Python2 anymore. 