### PR TITLE
Added missing parameter to image_data_generator.py

### DIFF
--- a/keras_preprocessing/image/affine_transformations.py
+++ b/keras_preprocessing/image/affine_transformations.py
@@ -232,7 +232,7 @@ def apply_brightness_shift(x, brightness, scale=True):
         raise ImportError('Using brightness shifts requires PIL. '
                           'Install PIL or Pillow.')
     x_min, x_max = np.min(x), np.max(x)
-    local_scale = (0 <= x_min <= x_max <= 255) or scale
+    local_scale = (x_min < 0) or (x_max > 255) or scale
     x = array_to_img(x, scale=local_scale)
     x = imgenhancer_Brightness = ImageEnhance.Brightness(x)
     x = imgenhancer_Brightness.enhance(brightness)

--- a/keras_preprocessing/image/affine_transformations.py
+++ b/keras_preprocessing/image/affine_transformations.py
@@ -231,10 +231,13 @@ def apply_brightness_shift(x, brightness, scale=True):
     if ImageEnhance is None:
         raise ImportError('Using brightness shifts requires PIL. '
                           'Install PIL or Pillow.')
+    x_min, x_max = np.min(x), np.max(x)
     x = array_to_img(x, scale=scale)
     x = imgenhancer_Brightness = ImageEnhance.Brightness(x)
     x = imgenhancer_Brightness.enhance(brightness)
     x = img_to_array(x)
+    if scale:
+        x = x / 255 * (x_max - x_min) + x_min
     return x
 
 

--- a/keras_preprocessing/image/affine_transformations.py
+++ b/keras_preprocessing/image/affine_transformations.py
@@ -232,12 +232,12 @@ def apply_brightness_shift(x, brightness, scale=True):
         raise ImportError('Using brightness shifts requires PIL. '
                           'Install PIL or Pillow.')
     x_min, x_max = np.min(x), np.max(x)
-    local_scale = (x_min < 0) or (x_max > 255) or scale
-    x = array_to_img(x, scale=local_scale)
+    local_scale = (x_min < 0) or (x_max > 255)
+    x = array_to_img(x, scale=local_scale or scale)
     x = imgenhancer_Brightness = ImageEnhance.Brightness(x)
     x = imgenhancer_Brightness.enhance(brightness)
     x = img_to_array(x)
-    if not local_scale:
+    if not scale and local_scale:
         x = x / 255 * (x_max - x_min) + x_min
     return x
 

--- a/keras_preprocessing/image/affine_transformations.py
+++ b/keras_preprocessing/image/affine_transformations.py
@@ -237,7 +237,7 @@ def apply_brightness_shift(x, brightness, scale=True):
     x = imgenhancer_Brightness = ImageEnhance.Brightness(x)
     x = imgenhancer_Brightness.enhance(brightness)
     x = img_to_array(x)
-    if not scale:
+    if not local_scale:
         x = x / 255 * (x_max - x_min) + x_min
     return x
 

--- a/keras_preprocessing/image/affine_transformations.py
+++ b/keras_preprocessing/image/affine_transformations.py
@@ -232,11 +232,12 @@ def apply_brightness_shift(x, brightness, scale=True):
         raise ImportError('Using brightness shifts requires PIL. '
                           'Install PIL or Pillow.')
     x_min, x_max = np.min(x), np.max(x)
-    x = array_to_img(x, scale=scale)
+    local_scale = (0 <= x_min <= x_max <= 255) or scale
+    x = array_to_img(x, scale=local_scale)
     x = imgenhancer_Brightness = ImageEnhance.Brightness(x)
     x = imgenhancer_Brightness.enhance(brightness)
     x = img_to_array(x)
-    if scale:
+    if not scale:
         x = x / 255 * (x_max - x_min) + x_min
     return x
 

--- a/keras_preprocessing/image/image_data_generator.py
+++ b/keras_preprocessing/image/image_data_generator.py
@@ -885,7 +885,7 @@ class ImageDataGenerator(object):
             x = flip_axis(x, img_row_axis)
 
         if transform_parameters.get('brightness') is not None:
-            x = apply_brightness_shift(x, transform_parameters['brightness'])
+            x = apply_brightness_shift(x, transform_parameters['brightness'], False)
 
         return x
 

--- a/keras_preprocessing/image/image_data_generator.py
+++ b/keras_preprocessing/image/image_data_generator.py
@@ -885,7 +885,7 @@ class ImageDataGenerator(object):
             x = flip_axis(x, img_row_axis)
 
         if transform_parameters.get('brightness') is not None:
-            x = apply_brightness_shift(x, transform_parameters['brightness'], False)
+            x = apply_brightness_shift(x, transform_parameters['brightness'])
 
         return x
 

--- a/tests/image/affine_transformations_test.py
+++ b/tests/image/affine_transformations_test.py
@@ -179,7 +179,7 @@ def test_random_brightness_scale():
     zeros = np.zeros((1, 1, 3))
     must_be_128 = affine_transformations.random_brightness(img, [1, 1], False)
     assert np.array_equal(img, must_be_128)
-    must_be_0 = affine_transformations.random_brightness(img, [1, 1], True)
+    must_be_0 = affine_transformations.random_brightness(zeros, [1, 1], True)
     assert np.array_equal(zeros, must_be_0)
 
 

--- a/tests/image/affine_transformations_test.py
+++ b/tests/image/affine_transformations_test.py
@@ -183,6 +183,24 @@ def test_random_brightness_scale():
     assert np.array_equal(zeros, must_be_0)
 
 
+def test_random_brightness_scale_outside_range_positive():
+    img = np.ones((1, 1, 3)) * 1024
+    zeros = np.zeros((1, 1, 3))
+    must_be_1024 = affine_transformations.random_brightness(img, [1, 1], False)
+    assert np.array_equal(img, must_be_1024)
+    must_be_0 = affine_transformations.random_brightness(img, [1, 1], True)
+    assert np.array_equal(zeros, must_be_0)
+
+
+def test_random_brightness_scale_outside_range_negative():
+    img = np.ones((1, 1, 3)) * -1024
+    zeros = np.zeros((1, 1, 3))
+    must_be_neg_1024 = affine_transformations.random_brightness(img, [1, 1], False)
+    assert np.array_equal(img, must_be_neg_1024)
+    must_be_0 = affine_transformations.random_brightness(img, [1, 1], True)
+    assert np.array_equal(zeros, must_be_0)
+
+
 def test_apply_affine_transform_error(monkeypatch):
     monkeypatch.setattr(affine_transformations, 'scipy', None)
     with pytest.raises(ImportError):

--- a/tests/image/affine_transformations_test.py
+++ b/tests/image/affine_transformations_test.py
@@ -179,7 +179,7 @@ def test_random_brightness_scale():
     zeros = np.zeros((1, 1, 3))
     must_be_128 = affine_transformations.random_brightness(img, [1, 1], False)
     assert np.array_equal(img, must_be_128)
-    must_be_0 = affine_transformations.random_brightness(zeros, [1, 1], True)
+    must_be_0 = affine_transformations.random_brightness(img, [1, 1], True)
     assert np.array_equal(zeros, must_be_0)
 
 


### PR DESCRIPTION
Prevents the apply_brightness_shift() function call to alter the image by min-max scaling it because of the missing scale parameter. Issue link: https://github.com/keras-team/keras-preprocessing/issues/327

# Summary (updated Dec 10, 2020)

## Problem description

I was using ImageDataGenerator with the parameter 'brightness_range'. This lead to unexpected behaviour where using the brightness range in interval [1,1] altered the image even though nothing should have happened. Looking more into the code, I noticed that the brightness range function generates a value 'brightness' from the uniform distribution with interval specified in the 'brightness_range' parameter, hence, the only value from U(1,1) must be 1. However, when the generated value 'brightness' is passed into the function apply_brightness_shift at line 888 seen below

https://github.com/keras-team/keras-preprocessing/blob/58df11e1145b2088092252c4dba02168c6da2b13/keras_preprocessing/image/image_data_generator.py#L888

the **scale parameter is ignored and leads to the function using the default parameter 'scale'=True** seen below:


https://github.com/keras-team/keras-preprocessing/blob/58df11e1145b2088092252c4dba02168c6da2b13/keras_preprocessing/image/affine_transformations.py#L215

This leads to a scaled output in range from [0-255] which **alters the original image value range image-wise**, and therefore performs unintentional min-max scaling to the input. Considering this function should only perform brightness modification and not per image min-max scaling of the values, such unexpected behaviour should not happen. 

## How I found this issue

I found this issue while using TensorFlow (2.3.1) package with function ImageDataGenerator which still relies on calls to keras API and took some time to locate where the issue is coming from.

## How to replicate the problem

```python
from tensorflow.keras.preprocessing.image import ImageDataGenerator
import numpy as np

old_image = np.random.randint(low=20,high=50,size=(1,10,10,1),dtype = 'uint8')

idg = ImageDataGenerator(brightness_range=(1,1)).flow(old_image) # unexpected behaviour

new_image = next(idg)[0].astype('uint8')

# output in range [20,50]
print(f'Original value range {old_image.min()} to {old_image.max()}')
# alters image and min-max scales it to range [0,255]
print(f'Original value range {new_image.min()} to {new_image.max()}')
```
This leads to the altered image:
> Original value range 20 to 49
> Original value range 0 to 255


## Solution

I propose to set the scale parameter in the line 888 to False which will perform the brightness_range without scaling and will return the expected outcome:

```python
 x = apply_brightness_shift(x, transform_parameters['brightness'], False) 
```


### Update (Dec 8, 2020)

After some headache, I found out a number of things:
1. In order to change brightness of the matrix, linear transformations are performed inside PIL library and that part of the code is actually private. Hence, it is not a simple value multiplication such as "brightness*x".
2. To solve this issue, we need to leave the functions as they are and add additional line of code to scale our image back to the input value range before returning if scaling is applied.

I suggested this in my updated commit:


3. I made some examples to show that my solution solves this issue:

For comparison, let's have two functions.

The original apply_brightness_shift(...)
```python
def old_apply_brightness_shift(x, brightness, scale=True):
    if ImageEnhance is None:
        raise ImportError('Using brightness shifts requires PIL. '
                          'Install PIL or Pillow.')
    x = array_to_img(x, scale=scale)
    x = imgenhancer_Brightness = ImageEnhance.Brightness(x)
    x = imgenhancer_Brightness.enhance(brightness)
    x = img_to_array(x)
    return x
```

The new apply_brightness_shift(...)
```python
def apply_brightness_shift(x, brightness, scale=True):
    if ImageEnhance is None:
        raise ImportError('Using brightness shifts requires PIL. '
                          'Install PIL or Pillow.')
    x_min, x_max = np.min(x), np.max(x)
    local_scale = (x_min < 0) or (x_max > 255)
    x = array_to_img(x, scale=local_scale or scale)
    x = imgenhancer_Brightness = ImageEnhance.Brightness(x)
    x = imgenhancer_Brightness.enhance(brightness)
    x = img_to_array(x)
    if not scale and local_scale:
        x = x / 255 * (x_max - x_min) + x_min
    return x
```

And let's create a function to compare input versus output and the difference between the two:
```python
def compare_input_output(input_img, brightness, scale, brightness_function):
    
    vmin=input_img.min()
    vmax=input_img.max()
    
    output_img = brightness_function(input_img, brightness=brightness, scale=scale)
    diff_img = output_img-input_img
    
    plt.figure(figsize=(9, 3))
    
    ax1 = plt.subplot(131)
    ax1.set_title('Input') 
    plt.imshow(input_img, vmin=vmin, vmax=vmax)
    
    ax2 = plt.subplot(132)
    ax2.set_title('Output') 
    plt.imshow(output_img, vmin=vmin, vmax=vmax)
    
    ax3 = plt.subplot(133)
    ax3.set_title('Difference') 
    plt.imshow(diff_img, vmin=vmin, vmax=vmax)
    
    
    get_stats = lambda img: list(np.array([img.mean(), img.min(), img.max()]).round())
    def print_stats(img, name): 
        print('{0} image mean={1} and range=({2},{3})'.format(name,*get_stats(img)))
    
    print("Brightness {}, scale {}".format(brightness, scale))
    print_stats(input_img, "Input")
    print_stats(output_img, "Output")
    print_stats(diff_img, "Difference")
```

Let our image be:
```
low = -1000
high = 1000
x = np.random.uniform(low=low,high=high,size=(10,10,1))
```

Then using the `compare_input_output` we get:
### OLD: 
`old_apply_brightness_shift` For scale set to False and brightness set to 1.0, 1.5 and 0.5 of the original brightness:

```bash
Brightness 1.0, scale False
Input image mean=-16.0 and range=(-993.0,996.0)
Output image mean=125.0 and range=(0.0,255.0)
Difference image mean=140.0 and range=(-741.0,993.0)
```
![image](https://user-images.githubusercontent.com/22203572/101501452-6c412700-3978-11eb-8a37-fb63d0f8b08a.png)

```bash
Brightness 1.5, scale False
Input image mean=-16.0 and range=(-993.0,996.0)
Output image mean=169.0 and range=(0.0,255.0)
Difference image mean=185.0 and range=(-741.0,993.0)
```
![image](https://user-images.githubusercontent.com/22203572/101501457-6ea38100-3978-11eb-9c6a-75bb51d3fec9.png)

```bash
Brightness 0.5, scale False
Input image mean=-16.0 and range=(-993.0,996.0)
Output image mean=62.0 and range=(0.0,127.0)
Difference image mean=78.0 and range=(-869.0,993.0)
```
![image](https://user-images.githubusercontent.com/22203572/101501467-72370800-3978-11eb-9dae-29e944021a3b.png)


### NEW: 
`apply_brightness_shift` For scale set to False and brightness set to 1.0, 1.5 and 0.5 of the original brightness:

```bash
Brightness 1.0, scale False
Input image mean=66.0 and range=(-978.0,983.0)
Output image mean=62.0 and range=(-978.0,983.0)
Difference image mean=-4.0 and range=(-8.0,0.0)
```
![image](https://user-images.githubusercontent.com/22203572/101501376-53d10c80-3978-11eb-8fc6-e36f5844ca0a.png)

```bash
Brightness 1.5, scale False
Input image mean=66.0 and range=(-978.0,983.0)
Output image mean=353.0 and range=(-978.0,983.0)
Difference image mean=287.0 and range=(-7.0,638.0)
```
![image](https://user-images.githubusercontent.com/22203572/101501390-57649380-3978-11eb-8475-6045f63f4721.png)

```bash
Brightness 0.5, scale False
Input image mean=66.0 and range=(-978.0,983.0)
Output image mean=-460.0 and range=(-978.0,-1.0)
Difference image mean=-526.0 and range=(-985.0,-0.0)
```
![image](https://user-images.githubusercontent.com/22203572/101501404-5a5f8400-3978-11eb-80e8-b7c71965e7bb.png)

### Update (Dec 10, 2020)
Added two tests for matrix values outside the expected [0,255] range:

```python
def test_random_brightness_scale_outside_range_positive():
    img = np.ones((1, 1, 3)) * 1024
    zeros = np.zeros((1, 1, 3))
    must_be_1024 = affine_transformations.random_brightness(img, [1, 1], False)
    assert np.array_equal(img, must_be_1024)
    must_be_0 = affine_transformations.random_brightness(img, [1, 1], True)
    assert np.array_equal(zeros, must_be_0)


def test_random_brightness_scale_outside_range_negative():
    img = np.ones((1, 1, 3)) * -1024
    zeros = np.zeros((1, 1, 3))
    must_be_neg_1024 = affine_transformations.random_brightness(img, [1, 1], False)
    assert np.array_equal(img, must_be_neg_1024)
    must_be_0 = affine_transformations.random_brightness(img, [1, 1], True)
    assert np.array_equal(zeros, must_be_0)
```

### Related Issues

https://github.com/keras-team/keras-preprocessing/issues/327

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [ ] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
