### PR TITLE
Changed default split when working on char_level 

### DIFF
--- a/keras_preprocessing/text.py
+++ b/keras_preprocessing/text.py
@@ -183,6 +183,8 @@ class Tokenizer(object):
         self.word_index = {}
         self.index_word = {}
         self.analyzer = analyzer
+        if char_level:
+          self.split = ""
 
     def fit_on_texts(self, texts):
         """Updates internal vocabulary based on a list of texts.


### PR DESCRIPTION
### Summary

When working i char_level the basic split should be empty string ("") instead of space (" ")

### Related Issues

### PR Overview

- [n ] This PR requires new unit tests [y/n] (make sure tests are included)
- [y] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
