### PR TITLE
Keep original aspect ratio of objects in flow_from_directory

### DIFF
--- a/keras_preprocessing/image/dataframe_iterator.py
+++ b/keras_preprocessing/image/dataframe_iterator.py
@@ -80,6 +80,9 @@ class DataFrameIterator(BatchFromFilesMixin, Iterator):
             If PIL version 1.1.3 or newer is installed, "lanczos" is also
             supported. If PIL version 3.4.0 or newer is installed, "box" and
             "hamming" are also supported. By default, "nearest" is used.
+        keep_aspect_ratio: Boolean, whether to resize images to a target size 
+            without aspect ratio distortion. The image is cropped in the center
+            with target aspect ratio before resizing.
         dtype: Dtype to use for the generated arrays.
         validate_filenames: Boolean, whether to validate image filenames in
         `x_col`. If `True`, invalid images will be ignored. Disabling this option
@@ -109,6 +112,7 @@ class DataFrameIterator(BatchFromFilesMixin, Iterator):
                  save_format='png',
                  subset=None,
                  interpolation='nearest',
+                 keep_aspect_ratio=False,
                  dtype='float32',
                  validate_filenames=True):
 
@@ -120,7 +124,8 @@ class DataFrameIterator(BatchFromFilesMixin, Iterator):
                                                             save_prefix,
                                                             save_format,
                                                             subset,
-                                                            interpolation)
+                                                            interpolation,
+                                                            keep_aspect_ratio)
         df = dataframe.copy()
         self.directory = directory or ''
         self.class_mode = class_mode

--- a/keras_preprocessing/image/dataframe_iterator.py
+++ b/keras_preprocessing/image/dataframe_iterator.py
@@ -80,7 +80,7 @@ class DataFrameIterator(BatchFromFilesMixin, Iterator):
             If PIL version 1.1.3 or newer is installed, "lanczos" is also
             supported. If PIL version 3.4.0 or newer is installed, "box" and
             "hamming" are also supported. By default, "nearest" is used.
-        keep_aspect_ratio: Boolean, whether to resize images to a target size 
+        keep_aspect_ratio: Boolean, whether to resize images to a target size
             without aspect ratio distortion. The image is cropped in the center
             with target aspect ratio before resizing.
         dtype: Dtype to use for the generated arrays.

--- a/keras_preprocessing/image/directory_iterator.py
+++ b/keras_preprocessing/image/directory_iterator.py
@@ -60,7 +60,7 @@ class DirectoryIterator(BatchFromFilesMixin, Iterator):
             If PIL version 1.1.3 or newer is installed, "lanczos" is also
             supported. If PIL version 3.4.0 or newer is installed, "box" and
             "hamming" are also supported. By default, "nearest" is used.
-        keep_aspect_ratio: Boolean, whether to resize images to a target size 
+        keep_aspect_ratio: Boolean, whether to resize images to a target size
             without aspect ratio distortion. The image is cropped in the center
             with target aspect ratio before resizing.
         dtype: Dtype to use for generated arrays.

--- a/keras_preprocessing/image/directory_iterator.py
+++ b/keras_preprocessing/image/directory_iterator.py
@@ -68,6 +68,7 @@ class DirectoryIterator(BatchFromFilesMixin, Iterator):
                  directory,
                  image_data_generator,
                  target_size=(256, 256),
+                 keep_aspect_ratio=False,
                  color_mode='rgb',
                  classes=None,
                  class_mode='categorical',
@@ -84,6 +85,7 @@ class DirectoryIterator(BatchFromFilesMixin, Iterator):
                  dtype='float32'):
         super(DirectoryIterator, self).set_processing_attrs(image_data_generator,
                                                             target_size,
+                                                            keep_aspect_ratio,
                                                             color_mode,
                                                             data_format,
                                                             save_to_dir,

--- a/keras_preprocessing/image/directory_iterator.py
+++ b/keras_preprocessing/image/directory_iterator.py
@@ -51,7 +51,7 @@ class DirectoryIterator(BatchFromFilesMixin, Iterator):
             images (if `save_to_dir` is set).
         save_format: Format to use for saving sample images
             (if `save_to_dir` is set).
-        follow_links: boolean,follow symbolic links to subdirectories
+        follow_links: Boolean, follow symbolic links to subdirectories
         subset: Subset of data (`"training"` or `"validation"`) if
             validation_split is set in ImageDataGenerator.
         interpolation: Interpolation method used to resample the image if the
@@ -60,6 +60,9 @@ class DirectoryIterator(BatchFromFilesMixin, Iterator):
             If PIL version 1.1.3 or newer is installed, "lanczos" is also
             supported. If PIL version 3.4.0 or newer is installed, "box" and
             "hamming" are also supported. By default, "nearest" is used.
+        keep_aspect_ratio: Boolean, whether to resize images to a target size 
+            without aspect ratio distortion. The image is cropped in the center
+            with target aspect ratio before resizing.
         dtype: Dtype to use for generated arrays.
     """
     allowed_class_modes = {'categorical', 'binary', 'sparse', 'input', None}
@@ -68,7 +71,6 @@ class DirectoryIterator(BatchFromFilesMixin, Iterator):
                  directory,
                  image_data_generator,
                  target_size=(256, 256),
-                 keep_aspect_ratio=False,
                  color_mode='rgb',
                  classes=None,
                  class_mode='categorical',
@@ -82,17 +84,18 @@ class DirectoryIterator(BatchFromFilesMixin, Iterator):
                  follow_links=False,
                  subset=None,
                  interpolation='nearest',
+                 keep_aspect_ratio=False,
                  dtype='float32'):
         super(DirectoryIterator, self).set_processing_attrs(image_data_generator,
                                                             target_size,
-                                                            keep_aspect_ratio,
                                                             color_mode,
                                                             data_format,
                                                             save_to_dir,
                                                             save_prefix,
                                                             save_format,
                                                             subset,
-                                                            interpolation)
+                                                            interpolation,
+                                                            keep_aspect_ratio)
         self.directory = directory
         self.classes = classes
         if class_mode not in self.allowed_class_modes:

--- a/keras_preprocessing/image/image_data_generator.py
+++ b/keras_preprocessing/image/image_data_generator.py
@@ -437,7 +437,6 @@ class ImageDataGenerator(object):
     def flow_from_directory(self,
                             directory,
                             target_size=(256, 256),
-                            keep_aspect_ratio=False,
                             color_mode='rgb',
                             classes=None,
                             class_mode='categorical',
@@ -449,7 +448,8 @@ class ImageDataGenerator(object):
                             save_format='png',
                             follow_links=False,
                             subset=None,
-                            interpolation='nearest'):
+                            interpolation='nearest',
+                            keep_aspect_ratio=False):
         """Takes the path to a directory & generates batches of augmented data.
 
         # Arguments
@@ -464,8 +464,6 @@ class ImageDataGenerator(object):
             target_size: Tuple of integers `(height, width)`,
                 default: `(256, 256)`.
                 The dimensions to which all images found will be resized.
-            keep_aspect_ratio:
-                TODO
             color_mode: One of "grayscale", "rgb", "rgba". Default: "rgb".
                 Whether the images will be converted to
                 have 1, 3, or 4 channels.
@@ -519,6 +517,9 @@ class ImageDataGenerator(object):
                 supported. If PIL version 3.4.0 or newer is installed,
                 `"box"` and `"hamming"` are also supported.
                 By default, `"nearest"` is used.
+            keep_aspect_ratio: Boolean, whether to resize images to a target
+                size without aspect ratio distortion. The image is cropped in
+                the center with target aspect ratio before resizing.
 
         # Returns
             A `DirectoryIterator` yielding tuples of `(x, y)`

--- a/keras_preprocessing/image/image_data_generator.py
+++ b/keras_preprocessing/image/image_data_generator.py
@@ -437,6 +437,7 @@ class ImageDataGenerator(object):
     def flow_from_directory(self,
                             directory,
                             target_size=(256, 256),
+                            keep_aspect_ratio=False,
                             color_mode='rgb',
                             classes=None,
                             class_mode='categorical',
@@ -463,6 +464,8 @@ class ImageDataGenerator(object):
             target_size: Tuple of integers `(height, width)`,
                 default: `(256, 256)`.
                 The dimensions to which all images found will be resized.
+            keep_aspect_ratio:
+                TODO
             color_mode: One of "grayscale", "rgb", "rgba". Default: "rgb".
                 Whether the images will be converted to
                 have 1, 3, or 4 channels.
@@ -527,6 +530,7 @@ class ImageDataGenerator(object):
             directory,
             self,
             target_size=target_size,
+            keep_aspect_ratio=keep_aspect_ratio,
             color_mode=color_mode,
             classes=classes,
             class_mode=class_mode,

--- a/keras_preprocessing/image/iterator.py
+++ b/keras_preprocessing/image/iterator.py
@@ -136,6 +136,7 @@ class BatchFromFilesMixin():
     def set_processing_attrs(self,
                              image_data_generator,
                              target_size,
+                             keep_aspect_ratio,
                              color_mode,
                              data_format,
                              save_to_dir,
@@ -171,6 +172,7 @@ class BatchFromFilesMixin():
         """
         self.image_data_generator = image_data_generator
         self.target_size = tuple(target_size)
+        self.keep_aspect_ratio = keep_aspect_ratio
         if color_mode not in {'rgb', 'rgba', 'grayscale'}:
             raise ValueError('Invalid color mode:', color_mode,
                              '; expected "rgb", "rgba", or "grayscale".')
@@ -227,7 +229,8 @@ class BatchFromFilesMixin():
             img = load_img(filepaths[j],
                            color_mode=self.color_mode,
                            target_size=self.target_size,
-                           interpolation=self.interpolation)
+                           interpolation=self.interpolation,
+                           keep_aspect_ratio=self.keep_aspect_ratio)
             x = img_to_array(img, data_format=self.data_format)
             # Pillow images should be closed after `load_img`,
             # but not PIL images.

--- a/keras_preprocessing/image/iterator.py
+++ b/keras_preprocessing/image/iterator.py
@@ -136,14 +136,14 @@ class BatchFromFilesMixin():
     def set_processing_attrs(self,
                              image_data_generator,
                              target_size,
-                             keep_aspect_ratio,
                              color_mode,
                              data_format,
                              save_to_dir,
                              save_prefix,
                              save_format,
                              subset,
-                             interpolation):
+                             interpolation,
+                             keep_aspect_ratio):
         """Sets attributes to use later for processing files into a batch.
 
         # Arguments

--- a/keras_preprocessing/image/utils.py
+++ b/keras_preprocessing/image/utils.py
@@ -95,6 +95,9 @@ def load_img(path, grayscale=False, color_mode='rgb', target_size=None,
             supported. If PIL version 3.4.0 or newer is installed, "box" and
             "hamming" are also supported.
             Default: "nearest".
+        keep_aspect_ratio: Boolean, whether to resize images to a target
+                size without aspect ratio distortion. The image is cropped in
+                the center with target aspect ratio before resizing.
 
     # Returns
         A PIL Image instance.
@@ -143,14 +146,20 @@ def load_img(path, grayscale=False, color_mode='rgb', target_size=None,
                     crop_height = (width * target_height) // target_width
                     crop_width = (height * target_width) // target_height
 
-                    # Set back to input height / width if crop_height / crop_width is not smaller.
+                    # Set back to input height / width 
+                    # if crop_height / crop_width is not smaller.
                     crop_height = min(height, crop_height)
                     crop_width = min(width, crop_width)
 
                     crop_box_hstart = (height - crop_height) // 2
                     crop_box_wstart = (width - crop_width) // 2
-                    crop_box = [crop_box_wstart, crop_box_hstart, crop_box_wstart+crop_width, crop_box_hstart+crop_height]
-                    img = img.resize(width_height_tuple, resample, box=crop_box)
+                    crop_box_hend = crop_box_wstart + crop_width
+                    crop_box_wend = crop_box_hstart + crop_height
+                    crop_box = [crop_box_wstart, crop_box_hstart,
+                                crop_box_wend, crop_box_hend]
+
+                    img = img.resize(width_height_tuple, resample,
+                                     box=crop_box)
                 else:
                     img = img.resize(width_height_tuple, resample)
         return img

--- a/keras_preprocessing/image/utils.py
+++ b/keras_preprocessing/image/utils.py
@@ -77,7 +77,7 @@ def save_img(path,
 
 
 def load_img(path, grayscale=False, color_mode='rgb', target_size=None,
-             interpolation='nearest'):
+             interpolation='nearest', keep_aspect_ratio=False):
     """Loads an image into PIL format.
 
     # Arguments
@@ -135,7 +135,20 @@ def load_img(path, grayscale=False, color_mode='rgb', target_size=None,
                             interpolation,
                             ", ".join(_PIL_INTERPOLATION_METHODS.keys())))
                 resample = _PIL_INTERPOLATION_METHODS[interpolation]
-                img = img.resize(width_height_tuple, resample)
+
+                if keep_aspect_ratio:
+                    img_temp = img.copy()
+
+                    # changes inplace without error exceptions
+                    img_temp.thumbnail(width_height_tuple, resample=resample)
+
+                    # check if resize was successful
+                    if width_height_tuple == img_temp.size:
+                        img = img_temp
+                    else:
+                        img = img.img_temp(width_height_tuple, resample)
+                else:
+                    img = img.resize(width_height_tuple, resample)
         return img
 
 

--- a/keras_preprocessing/image/utils.py
+++ b/keras_preprocessing/image/utils.py
@@ -146,7 +146,7 @@ def load_img(path, grayscale=False, color_mode='rgb', target_size=None,
                     crop_height = (width * target_height) // target_width
                     crop_width = (height * target_width) // target_height
 
-                    # Set back to input height / width 
+                    # Set back to input height / width
                     # if crop_height / crop_width is not smaller.
                     crop_height = min(height, crop_height)
                     crop_width = min(width, crop_width)

--- a/keras_preprocessing/image/utils.py
+++ b/keras_preprocessing/image/utils.py
@@ -137,16 +137,20 @@ def load_img(path, grayscale=False, color_mode='rgb', target_size=None,
                 resample = _PIL_INTERPOLATION_METHODS[interpolation]
 
                 if keep_aspect_ratio:
-                    img_temp = img.copy()
+                    width, height = img.size
+                    target_width, target_height = width_height_tuple
 
-                    # changes inplace without error exceptions
-                    img_temp.thumbnail(width_height_tuple, resample=resample)
+                    crop_height = (width * target_height) // target_width
+                    crop_width = (height * target_width) // target_height
 
-                    # check if resize was successful
-                    if width_height_tuple == img_temp.size:
-                        img = img_temp
-                    else:
-                        img = img.img_temp(width_height_tuple, resample)
+                    # Set back to input height / width if crop_height / crop_width is not smaller.
+                    crop_height = min(height, crop_height)
+                    crop_width = min(width, crop_width)
+
+                    crop_box_hstart = (height - crop_height) // 2
+                    crop_box_wstart = (width - crop_width) // 2
+                    crop_box = [crop_box_wstart, crop_box_hstart, crop_box_wstart+crop_width, crop_box_hstart+crop_height]
+                    img = img.resize(width_height_tuple, resample, box=crop_box)
                 else:
                     img = img.resize(width_height_tuple, resample)
         return img

--- a/keras_preprocessing/image/utils.py
+++ b/keras_preprocessing/image/utils.py
@@ -153,8 +153,8 @@ def load_img(path, grayscale=False, color_mode='rgb', target_size=None,
 
                     crop_box_hstart = (height - crop_height) // 2
                     crop_box_wstart = (width - crop_width) // 2
-                    crop_box_hend = crop_box_wstart + crop_width
-                    crop_box_wend = crop_box_hstart + crop_height
+                    crop_box_wend = crop_box_wstart + crop_width
+                    crop_box_hend = crop_box_hstart + crop_height
                     crop_box = [crop_box_wstart, crop_box_hstart,
                                 crop_box_wend, crop_box_hend]
 

--- a/tests/image/utils_test.py
+++ b/tests/image/utils_test.py
@@ -199,11 +199,11 @@ def test_load_img(tmpdir):
         loaded_im = utils.load_img(filename_rgb, target_size=(25, 25),
                                    interpolation="unsupported")
 
-    # Check that the aspect ratio is the same
+    # Check that the aspect ratio of a square is the same
 
     filename_red_square = str(tmpdir / 'red_square_utils.png')
-    A = np.zeros((50, 100, 3), dtype=np.uint8)
-    A[20:30, 45:55, 0] = 255  # red rectangle 10x10
+    A = np.zeros((50, 100, 3), dtype=np.uint8)  # rectangle image 100x50
+    A[20:30, 45:55, 0] = 255  # red square 10x10
     red_square_array = np.array(A)
     red_square = utils.array_to_img(red_square_array, scale=False)
     red_square.save(filename_red_square)

--- a/tests/image/utils_test.py
+++ b/tests/image/utils_test.py
@@ -208,8 +208,8 @@ def test_load_img(tmpdir):
     red_square = utils.array_to_img(red_square_array, scale=False)
     red_square.save(filename_red_square)
 
-    loaded_im = utils.load_img(filename_red_square, target_size=(25, 25), 
-        keep_aspect_ratio=True)
+    loaded_im = utils.load_img(filename_red_square, target_size=(25, 25),
+                               keep_aspect_ratio=True)
     loaded_im_array = utils.img_to_array(loaded_im)
     assert loaded_im_array.shape == (25, 25, 3)
 
@@ -217,7 +217,7 @@ def test_load_img(tmpdir):
     square_width = np.sum(np.sum(red_channel_arr, axis=0))
     square_height = np.sum(np.sum(red_channel_arr, axis=1))
     aspect_ratio_result = square_width / square_height
-    
+
     # original square had 1:1 ratio
     assert aspect_ratio_result == pytest.approx(1.0)
 

--- a/tests/image/utils_test.py
+++ b/tests/image/utils_test.py
@@ -199,6 +199,28 @@ def test_load_img(tmpdir):
         loaded_im = utils.load_img(filename_rgb, target_size=(25, 25),
                                    interpolation="unsupported")
 
+    # Check that the aspect ratio is the same
+
+    filename_red_square = str(tmpdir / 'red_square_utils.png')
+    A = np.zeros((50, 100, 3), dtype=np.uint8)
+    A[20:30, 45:55, 0] = 255  # red rectangle 10x10
+    red_square_array = np.array(A)
+    red_square = utils.array_to_img(red_square_array, scale=False)
+    red_square.save(filename_red_square)
+
+    loaded_im = utils.load_img(filename_red_square, target_size=(25, 25), 
+        keep_aspect_ratio=True)
+    loaded_im_array = utils.img_to_array(loaded_im)
+    assert loaded_im_array.shape == (25, 25, 3)
+
+    red_channel_arr = loaded_im_array[:, :, 0].astype(np.bool)
+    square_width = np.sum(np.sum(red_channel_arr, axis=0))
+    square_height = np.sum(np.sum(red_channel_arr, axis=1))
+    aspect_ratio_result = square_width / square_height
+    
+    # original square had 1:1 ratio
+    assert aspect_ratio_result == pytest.approx(1.0)
+
 
 def test_list_pictures(tmpdir):
     filenames = ['test.png', 'test0.jpg', 'test-1.jpeg', '2test.bmp',


### PR DESCRIPTION
### Summary

Often while using `ImageDataGenerator` from local images, you want to maintain the aspect ratio of the objects itself in order to avoid models to learn the retransformation. This flag allows to maintain original aspect ratio of the objects.

An additional parameter in `flow_from_directory` is introduced, i.e. `train_datagen.flow_from_directory(keep_aspect_ratio=True)`.

![before](https://user-images.githubusercontent.com/12762439/105099563-2b2a4f80-5aac-11eb-956c-302e6ac52fce.png)

![after](https://user-images.githubusercontent.com/12762439/105099596-38473e80-5aac-11eb-82e1-0bf43c0d4203.png)

In `tensorflow` there is https://www.tensorflow.org/api_docs/python/tf/keras/preprocessing/image/smart_resize?hl=en , copied the logic from there, since reuse was not possible due circular import ...

### Related Issues

https://github.com/keras-team/keras/pull/4987/files

https://stackoverflow.com/questions/42467734/keras-how-to-use-imagedatagenerator-without-deforming-aspect-ratio

### PR Overview

- [y] This PR requires new unit tests [y/n] (make sure tests are included)
- [y] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [y] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
