### PR TITLE
Removed SciPy dependency.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ and is distributed under the MIT license.
 '''
 
 setup(name='Keras_Preprocessing',
-      version='1.1.2',
+      version='1.1.3',
       description='Easy data preprocessing and data augmentation '
                   'for deep learning models',
       long_description=long_description,
@@ -33,13 +33,14 @@ setup(name='Keras_Preprocessing',
       extras_require={
           'tests': ['pandas',
                     'Pillow',
-                    'tensorflow',  # CPU version
+                    'tensorflow>=2.4.0',  # CPU version
                     'keras',
                     'pytest',
                     'pytest-xdist',
                     'pytest-cov'],
           'pep8': ['flake8'],
-          'image': ['scipy>=0.14',
+          'image': ['tensorflow>=2.4.0'
+                    'tensorflow-addons>=0.12.0',
                     'Pillow>=5.2.0'],
       },
       classifiers=[

--- a/tests/image/affine_transformations_test.py
+++ b/tests/image/affine_transformations_test.py
@@ -200,8 +200,3 @@ def test_random_brightness_scale_outside_range_negative():
     must_be_0 = affine_transformations.random_brightness(img, [1, 1], True)
     assert np.array_equal(zeros, must_be_0)
 
-
-def test_apply_affine_transform_error(monkeypatch):
-    monkeypatch.setattr(affine_transformations, 'scipy', None)
-    with pytest.raises(ImportError):
-        affine_transformations.apply_affine_transform(0)


### PR DESCRIPTION
### Summary

### Related Issues

### PR Overview

- [n] This PR requires new unit tests [y/n] (make sure tests are included)
- [n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)

This is the second (last) part of the effort to remove SciPy dependency (#322)

Note: currently two tests are failing because of a bug tensorflow/addons#2357. Since the issue is not critical -- it only affects boundaries, we can adjust unit tests to follow the buggy behavior of `tensorflow-addons`.