### PR TITLE
To support io.Byteio

### DIFF
--- a/keras_preprocessing/image/utils.py
+++ b/keras_preprocessing/image/utils.py
@@ -121,7 +121,6 @@ def load_img(path, grayscale=False, color_mode='rgb', target_size=None,
     else:
         raise TypeError('path should be path-like or io.BytesIO, not {}'.format(type(path)))
 
-
     if color_mode == 'grayscale':
         # if image is not already an 8-bit, 16-bit or 32-bit grayscale image
         # convert it to an 8-bit grayscale image.
@@ -162,14 +161,11 @@ def load_img(path, grayscale=False, color_mode='rgb', target_size=None,
                 crop_box_wstart = (width - crop_width) // 2
                 crop_box_wend = crop_box_wstart + crop_width
                 crop_box_hend = crop_box_hstart + crop_height
-                crop_box = [crop_box_wstart, crop_box_hstart,
-                            crop_box_wend, crop_box_hend]
-
-                img = img.resize(width_height_tuple, resample,
-                                    box=crop_box)
+                crop_box = [crop_box_wstart, crop_box_hstart, crop_box_wend, crop_box_hend]
+                img = img.resize(width_height_tuple, resample, box=crop_box)
             else:
                 img = img.resize(width_height_tuple, resample)
-        return img
+    return img
 
 
 def list_pictures(directory, ext=('jpg', 'jpeg', 'bmp', 'png', 'ppm', 'tif',

--- a/keras_preprocessing/image/utils.py
+++ b/keras_preprocessing/image/utils.py
@@ -119,7 +119,8 @@ def load_img(path, grayscale=False, color_mode='rgb', target_size=None,
         with open(path, 'rb') as f:
             img = pil_image.open(io.BytesIO(f.read()))
     else:
-        raise TypeError('path should be path-like or io.BytesIO, not {}'.format(type(path)))
+        raise TypeError('path should be path-like or io.BytesIO'
+                        ', not {}'.format(type(path)))
 
     if color_mode == 'grayscale':
         # if image is not already an 8-bit, 16-bit or 32-bit grayscale image
@@ -161,7 +162,8 @@ def load_img(path, grayscale=False, color_mode='rgb', target_size=None,
                 crop_box_wstart = (width - crop_width) // 2
                 crop_box_wend = crop_box_wstart + crop_width
                 crop_box_hend = crop_box_hstart + crop_height
-                crop_box = [crop_box_wstart, crop_box_hstart, crop_box_wend, crop_box_hend]
+                crop_box = [crop_box_wstart, crop_box_hstart,
+                            crop_box_wend, crop_box_hend]
                 img = img.resize(width_height_tuple, resample, box=crop_box)
             else:
                 img = img.resize(width_height_tuple, resample)


### PR DESCRIPTION
### Summary
```
from keras_preprocessing import image 
image.load_img(**path**, target_size)
```

path can be io.Byteio before, but due to the fix in #261. It doesn't work anymore. 
I also read issues #293 and #294 for compatibility. Please let me know if there is any concerns.

### Related Issues
#261
#293
#294

### PR Overview

- [n] This PR requires new unit tests [y/n] (make sure tests are included)
- [n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
