### PR TITLE
To support io.Bytesio

### DIFF
--- a/keras_preprocessing/image/utils.py
+++ b/keras_preprocessing/image/utils.py
@@ -14,6 +14,7 @@ except ImportError:
     pil_image = None
     ImageEnhance = None
 
+
 if pil_image is not None:
     _PIL_INTERPOLATION_METHODS = {
         'nearest': pil_image.NEAREST,
@@ -40,8 +41,8 @@ def validate_filename(filename, white_list_formats):
     # Returns
         A boolean value indicating if the filename is valid or not
     """
-    return (filename.lower().endswith(white_list_formats)
-            and os.path.isfile(filename))
+    return (filename.lower().endswith(white_list_formats) and
+            os.path.isfile(filename))
 
 
 def save_img(path,
@@ -72,12 +73,8 @@ def save_img(path,
     img.save(path, format=file_format, **kwargs)
 
 
-def load_img(path,
-             grayscale=False,
-             color_mode='rgb',
-             target_size=None,
-             interpolation='nearest',
-             keep_aspect_ratio=False):
+def load_img(path, grayscale=False, color_mode='rgb', target_size=None,
+             interpolation='nearest', keep_aspect_ratio=False):
     """Loads an image into PIL format.
 
     # Arguments
@@ -175,8 +172,8 @@ def load_img(path,
     return img
 
 
-def list_pictures(directory,
-                  ext=('jpg', 'jpeg', 'bmp', 'png', 'ppm', 'tif', 'tiff')):
+def list_pictures(directory, ext=('jpg', 'jpeg', 'bmp', 'png', 'ppm', 'tif',
+                                  'tiff')):
     """Lists all pictures in a directory, including all subdirectories.
 
     # Arguments
@@ -186,11 +183,10 @@ def list_pictures(directory,
     # Returns
         a list of paths
     """
-    ext = tuple('.%s' % e for e in ((ext, ) if isinstance(ext, str) else ext))
-    return [
-        os.path.join(root, f) for root, _, files in os.walk(directory)
-        for f in files if f.lower().endswith(ext)
-    ]
+    ext = tuple('.%s' % e for e in ((ext,) if isinstance(ext, str) else ext))
+    return [os.path.join(root, f)
+            for root, _, files in os.walk(directory) for f in files
+            if f.lower().endswith(ext)]
 
 
 def _iter_valid_files(directory, white_list_formats, follow_links):
@@ -213,9 +209,8 @@ def _iter_valid_files(directory, white_list_formats, follow_links):
     for root, _, files in _recursive_list(directory):
         for fname in sorted(files):
             if fname.lower().endswith('.tiff'):
-                warnings.warn(
-                    'Using ".tiff" files with multiple bands '
-                    'will cause distortion. Please verify your output.')
+                warnings.warn('Using ".tiff" files with multiple bands '
+                              'will cause distortion. Please verify your output.')
             if fname.lower().endswith(white_list_formats):
                 yield root, fname
 
@@ -246,21 +241,21 @@ def _list_valid_filenames_in_directory(directory, white_list_formats, split,
     """
     dirname = os.path.basename(directory)
     if split:
-        all_files = list(
-            _iter_valid_files(directory, white_list_formats, follow_links))
+        all_files = list(_iter_valid_files(directory, white_list_formats,
+                                           follow_links))
         num_files = len(all_files)
         start, stop = int(split[0] * num_files), int(split[1] * num_files)
-        valid_files = all_files[start:stop]
+        valid_files = all_files[start: stop]
     else:
-        valid_files = _iter_valid_files(directory, white_list_formats,
-                                        follow_links)
+        valid_files = _iter_valid_files(
+            directory, white_list_formats, follow_links)
     classes = []
     filenames = []
     for root, fname in valid_files:
         classes.append(class_indices[dirname])
         absolute_path = os.path.join(root, fname)
-        relative_path = os.path.join(dirname,
-                                     os.path.relpath(absolute_path, directory))
+        relative_path = os.path.join(
+            dirname, os.path.relpath(absolute_path, directory))
         filenames.append(relative_path)
 
     return classes, filenames
@@ -292,7 +287,7 @@ def array_to_img(x, data_format='channels_last', scale=True, dtype='float32'):
     x = np.asarray(x, dtype=dtype)
     if x.ndim != 3:
         raise ValueError('Expected image array to have rank 3 (single image). '
-                         'Got array with shape: %s' % (x.shape, ))
+                         'Got array with shape: %s' % (x.shape,))
 
     if data_format not in {'channels_first', 'channels_last'}:
         raise ValueError('Invalid data_format: %s' % data_format)
@@ -321,7 +316,7 @@ def array_to_img(x, data_format='channels_last', scale=True, dtype='float32'):
             return pil_image.fromarray(x[:, :, 0].astype('int32'), 'I')
         return pil_image.fromarray(x[:, :, 0].astype('uint8'), 'L')
     else:
-        raise ValueError('Unsupported channel number: %s' % (x.shape[2], ))
+        raise ValueError('Unsupported channel number: %s' % (x.shape[2],))
 
 
 def img_to_array(img, data_format='channels_last', dtype='float32'):
@@ -354,5 +349,5 @@ def img_to_array(img, data_format='channels_last', dtype='float32'):
         else:
             x = x.reshape((x.shape[0], x.shape[1], 1))
     else:
-        raise ValueError('Unsupported image shape: %s' % (x.shape, ))
+        raise ValueError('Unsupported image shape: %s' % (x.shape,))
     return x

--- a/keras_preprocessing/image/utils.py
+++ b/keras_preprocessing/image/utils.py
@@ -32,9 +32,11 @@ if pil_image is not None:
 
 def validate_filename(filename, white_list_formats):
     """Check if a filename refers to a valid file.
+
     # Arguments
         filename: String, absolute path to a file
         white_list_formats: Set, allowed file extensions
+
     # Returns
         A boolean value indicating if the filename is valid or not
     """
@@ -49,6 +51,7 @@ def save_img(path,
              scale=True,
              **kwargs):
     """Saves an image stored as a Numpy array to a path or file object.
+
     # Arguments
         path: Path or file object.
         x: Numpy array.
@@ -76,6 +79,7 @@ def load_img(path,
              interpolation='nearest',
              keep_aspect_ratio=False):
     """Loads an image into PIL format.
+
     # Arguments
         path: Path (string), pathlib.Path object, or io.BytesIO stream to image file.
         grayscale: DEPRECATED use `color_mode="grayscale"`.
@@ -94,8 +98,10 @@ def load_img(path,
         keep_aspect_ratio: Boolean, whether to resize images to a target
                 size without aspect ratio distortion. The image is cropped in
                 the center with target aspect ratio before resizing.
+
     # Returns
         A PIL Image instance.
+
     # Raises
         ImportError: if PIL is not available.
         ValueError: if interpolation method is not supported.
@@ -172,9 +178,11 @@ def load_img(path,
 def list_pictures(directory,
                   ext=('jpg', 'jpeg', 'bmp', 'png', 'ppm', 'tif', 'tiff')):
     """Lists all pictures in a directory, including all subdirectories.
+
     # Arguments
         directory: string, absolute path to the directory
         ext: tuple of strings or single string, extensions of the pictures
+
     # Returns
         a list of paths
     """
@@ -187,12 +195,14 @@ def list_pictures(directory,
 
 def _iter_valid_files(directory, white_list_formats, follow_links):
     """Iterates on files with extension in `white_list_formats` contained in `directory`.
+
     # Arguments
         directory: Absolute path to the directory
             containing files to be counted
         white_list_formats: Set of strings containing allowed extensions for
             the files to be counted.
         follow_links: Boolean, follow symbolic links to subdirectories.
+
     # Yields
         Tuple of (root, filename) with extension in `white_list_formats`.
     """
@@ -213,6 +223,7 @@ def _iter_valid_files(directory, white_list_formats, follow_links):
 def _list_valid_filenames_in_directory(directory, white_list_formats, split,
                                        class_indices, follow_links):
     """Lists paths of files in `subdir` with extensions in `white_list_formats`.
+
     # Arguments
         directory: absolute path to a directory containing the files to list.
             The directory name is used as class label
@@ -225,6 +236,7 @@ def _list_valid_filenames_in_directory(directory, white_list_formats, split,
             of images in each directory.
         class_indices: dictionary mapping a class name to its index.
         follow_links: boolean, follow symbolic links to subdirectories.
+
     # Returns
          classes: a list of class indices
          filenames: the path of valid files in `directory`, relative from
@@ -256,6 +268,7 @@ def _list_valid_filenames_in_directory(directory, white_list_formats, split,
 
 def array_to_img(x, data_format='channels_last', scale=True, dtype='float32'):
     """Converts a 3D Numpy array to a PIL Image instance.
+
     # Arguments
         x: Input Numpy array.
         data_format: Image data format, either "channels_first" or "channels_last".
@@ -265,8 +278,10 @@ def array_to_img(x, data_format='channels_last', scale=True, dtype='float32'):
             Default: True.
         dtype: Dtype to use.
             Default: "float32".
+
     # Returns
         A PIL Image instance.
+
     # Raises
         ImportError: if PIL is not available.
         ValueError: if invalid `x` or `data_format` is passed.
@@ -311,13 +326,16 @@ def array_to_img(x, data_format='channels_last', scale=True, dtype='float32'):
 
 def img_to_array(img, data_format='channels_last', dtype='float32'):
     """Converts a PIL Image instance to a Numpy array.
+
     # Arguments
         img: PIL Image instance.
         data_format: Image data format,
             either "channels_first" or "channels_last".
         dtype: Dtype to use for the returned array.
+
     # Returns
         A 3D Numpy array.
+
     # Raises
         ValueError: if invalid `img` or `data_format` is passed.
     """

--- a/tests/image/utils_test.py
+++ b/tests/image/utils_test.py
@@ -1,5 +1,6 @@
 import io
 import resource
+from pathlib import Path
 
 import numpy as np
 import PIL
@@ -211,7 +212,7 @@ def test_load_img(tmpdir):
     loaded_im_array = utils.img_to_array(loaded_im, dtype=np.int32)
     assert np.all(loaded_im_array == original_grayscale_32bit_array)
 
-    _path = tmpdir / 'grayscale_32bit_utils.tiff'  # Path
+    _path = Path(tmpdir / 'grayscale_32bit_utils.tiff')  # Path
     loaded_im = utils.load_img(_path, color_mode='grayscale')
     loaded_im_array = utils.img_to_array(loaded_im, dtype=np.int32)
     assert np.all(loaded_im_array == original_grayscale_32bit_array)

--- a/tests/image/utils_test.py
+++ b/tests/image/utils_test.py
@@ -199,22 +199,22 @@ def test_load_img(tmpdir):
         _path = io.BytesIO(f.read())  # io.Bytesio
     loaded_im = utils.load_img(_path, color_mode='grayscale')
     loaded_im_array = utils.img_to_array(loaded_im, dtype=np.int32)
-    assert loaded_im_array == original_grayscale_32bit_array
+    assert np.all(loaded_im_array == original_grayscale_32bit_array)
 
     _path = filename_grayscale_32bit    # str
     loaded_im = utils.load_img(_path, color_mode='grayscale')
     loaded_im_array = utils.img_to_array(loaded_im, dtype=np.int32)
-    assert loaded_im_array == original_grayscale_32bit_array
+    assert np.all(loaded_im_array == original_grayscale_32bit_array)
 
     _path = filename_grayscale_32bit.encode()  # bytes
     loaded_im = utils.load_img(_path, color_mode='grayscale')
     loaded_im_array = utils.img_to_array(loaded_im, dtype=np.int32)
-    assert loaded_im_array == original_grayscale_32bit_array
+    assert np.all(loaded_im_array == original_grayscale_32bit_array)
 
     _path = tmpdir / 'grayscale_32bit_utils.tiff'  # Path
     loaded_im = utils.load_img(_path, color_mode='grayscale')
     loaded_im_array = utils.img_to_array(loaded_im, dtype=np.int32)
-    assert loaded_im_array == original_grayscale_32bit_array
+    assert np.all(loaded_im_array == original_grayscale_32bit_array)
 
     # Check that exception is raised if interpolation not supported.
 

--- a/tests/image/utils_test.py
+++ b/tests/image/utils_test.py
@@ -1,3 +1,4 @@
+import io
 import resource
 
 import numpy as np
@@ -192,6 +193,20 @@ def test_load_img(tmpdir):
                                target_size=(25, 25), interpolation="nearest")
     loaded_im_array = utils.img_to_array(loaded_im, dtype='int32')
     assert loaded_im_array.shape == (25, 25, 1)
+
+    # Test different path type
+    with open(filename_grayscale_32bit, 'rb') as f:
+        _path = io.BytesIO(f.read())  # io.Bytesio
+    loaded_im = utils.load_img(_path, color_mode='grayscale')
+    assert loaded_im == original_grayscale_32bit
+
+    _path = filename_grayscale_32bit    # str
+    loaded_im = utils.load_img(_path, color_mode='grayscale')
+    assert loaded_im == original_grayscale_32bit
+
+    _path = filename_grayscale_32bit.encode()  # bytes
+    loaded_im = utils.load_img(_path, color_mode='grayscale')
+    assert loaded_im == original_grayscale_32bit
 
     # Check that exception is raised if interpolation not supported.
 

--- a/tests/image/utils_test.py
+++ b/tests/image/utils_test.py
@@ -198,15 +198,23 @@ def test_load_img(tmpdir):
     with open(filename_grayscale_32bit, 'rb') as f:
         _path = io.BytesIO(f.read())  # io.Bytesio
     loaded_im = utils.load_img(_path, color_mode='grayscale')
-    assert loaded_im == original_grayscale_32bit
+    loaded_im_array = utils.img_to_array(loaded_im, dtype=np.int32)
+    assert loaded_im_array == original_grayscale_32bit_array
 
     _path = filename_grayscale_32bit    # str
     loaded_im = utils.load_img(_path, color_mode='grayscale')
-    assert loaded_im == original_grayscale_32bit
+    loaded_im_array = utils.img_to_array(loaded_im, dtype=np.int32)
+    assert loaded_im_array == original_grayscale_32bit_array
 
     _path = filename_grayscale_32bit.encode()  # bytes
     loaded_im = utils.load_img(_path, color_mode='grayscale')
-    assert loaded_im == original_grayscale_32bit
+    loaded_im_array = utils.img_to_array(loaded_im, dtype=np.int32)
+    assert loaded_im_array == original_grayscale_32bit_array
+
+    _path = tmpdir / 'grayscale_32bit_utils.tiff'  # Path
+    loaded_im = utils.load_img(_path, color_mode='grayscale')
+    loaded_im_array = utils.img_to_array(loaded_im, dtype=np.int32)
+    assert loaded_im_array == original_grayscale_32bit_array
 
     # Check that exception is raised if interpolation not supported.
 


### PR DESCRIPTION
### Summary
```
from keras_preprocessing import image 
image.load_img(**path**, target_size)
```

path can be io.Byteio before, but due to the fix in #261. It doesn't work anymore. 
I also read issues #293 and #294 for compatibility. Please let me know if there is any concerns.

### Related Issues
#261
#293
#294

### PR Overview

- [n] This PR requires new unit tests [y/n] (make sure tests are included)
- [n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
