### PR TITLE
remove dtype from np.asarray

### DIFF
--- a/keras_preprocessing/image/utils.py
+++ b/keras_preprocessing/image/utils.py
@@ -284,7 +284,7 @@ def array_to_img(x, data_format='channels_last', scale=True, dtype='float32'):
     if pil_image is None:
         raise ImportError('Could not import PIL.Image. '
                           'The use of `array_to_img` requires PIL.')
-    x = np.asarray(x, dtype=dtype)
+    x = np.asarray(x)
     if x.ndim != 3:
         raise ValueError('Expected image array to have rank 3 (single image). '
                          'Got array with shape: %s' % (x.shape,))


### PR DESCRIPTION
The recent version of numpy automatically select a data type and accept one positional argument. The dtype return a dependencies error 

'in asarray return array(a, dtype, copy=False, order=order) TypeError: __array__() takes 1 positional argument but 2 were given -->'

### Summary

### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [ ] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
