### PR TITLE
fix(NumpyArrayIterator): for determistic results

### DIFF
--- a/keras_preprocessing/image/numpy_array_iterator.py
+++ b/keras_preprocessing/image/numpy_array_iterator.py
@@ -158,7 +158,7 @@ class NumpyArrayIterator(Iterator):
                            dtype=self.dtype)
         for i, j in enumerate(index_array):
             x = self.x[j]
-            params = self.image_data_generator.get_random_transform(x.shape)
+            params = self.image_data_generator.get_random_transform(x.shape, seed=self.seed)
             x = self.image_data_generator.apply_transform(
                 x.astype(self.dtype), params)
             x = self.image_data_generator.standardize(x)


### PR DESCRIPTION
Add the missng ssed argument to `self.image_data_generator.get_random_transform` for  determistic results.
Especially during mutli-thread, we cannot set numpy.rand.seed out of the thread, this arugment pass is important!

### Summary

### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [ ] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
